### PR TITLE
Add Courtesan merit threshold to character promotion

### DIFF
--- a/Domain/Entity/Character.cs
+++ b/Domain/Entity/Character.cs
@@ -26,6 +26,7 @@ namespace SkyHorizont.Domain.Entity
         private static readonly Dictionary<Rank, int> MeritThresholds = new()
         {
             { Rank.Civilian, 0 },
+            { Rank.Courtesan, 100 },
             { Rank.Lieutenant, 100 },
             { Rank.Captain, 300 },
             { Rank.Major, 700 },


### PR DESCRIPTION
## Summary
- add missing merit threshold for the Courtesan rank to avoid KeyNotFound errors during merit calculations

## Testing
- `dotnet test` *(fails: Expected characters.GetAll().Count() to be 25, but found 2; and other PiracyService constructor ArgumentNullException)*

------
https://chatgpt.com/codex/tasks/task_e_68aae54baf7c8321aaf20f5562bff53f