### PR TITLE
refactor: modular intent planning

### DIFF
--- a/Domain/Social/IIntentRule.cs
+++ b/Domain/Social/IIntentRule.cs
@@ -1,0 +1,10 @@
+namespace SkyHorizont.Domain.Social
+{
+    /// <summary>
+    /// Generates scored intents for a single intent type.
+    /// </summary>
+    public interface IIntentRule
+    {
+        IEnumerable<ScoredIntent> Generate(IntentContext context);
+    }
+}

--- a/Domain/Social/IntentContext.cs
+++ b/Domain/Social/IntentContext.cs
@@ -1,0 +1,58 @@
+using SkyHorizont.Domain.Entity;
+using SkyHorizont.Domain.Factions;
+using SkyHorizont.Domain.Galaxy.Planet;
+using SkyHorizont.Domain.Travel;
+
+namespace SkyHorizont.Domain.Social
+{
+    /// <summary>Shared data available to intent rules for a single actor.</summary>
+    public sealed class IntentContext
+    {
+        public Character Actor { get; }
+        public Guid ActorFactionId { get; }
+        public FactionStatus FactionStatus { get; }
+        public Guid? ActorSystemId { get; }
+        public SystemSecurity? SystemSecurity { get; }
+        public Guid? ActorLeaderId { get; }
+        public IReadOnlyList<Character> SameFactionCharacters { get; }
+        public IReadOnlyList<Character> OtherFactionCharacters { get; }
+        public IReadOnlyList<Character> Captives { get; }
+        public CharacterAmbition Ambition { get; }
+        public (double Court, double Family, double Spy, double Bribe, double Recruit, double Defect, double Negotiate, double Quarrel, double Assassinate, double Torture, double Rape, double Travel, double BecomePirate, double RaidConvoy) AmbitionBias { get; }
+        public Func<Guid, int> OpinionOf { get; }
+        public Func<Guid, Guid> FactionOf { get; }
+        public PlannerConfig Config { get; }
+
+        public IntentContext(
+            Character actor,
+            Guid actorFactionId,
+            FactionStatus factionStatus,
+            Guid? actorSystemId,
+            SystemSecurity? systemSecurity,
+            Guid? actorLeaderId,
+            IReadOnlyList<Character> sameFactionCharacters,
+            IReadOnlyList<Character> otherFactionCharacters,
+            IReadOnlyList<Character> captives,
+            CharacterAmbition ambition,
+            (double Court, double Family, double Spy, double Bribe, double Recruit, double Defect, double Negotiate, double Quarrel, double Assassinate, double Torture, double Rape, double Travel, double BecomePirate, double RaidConvoy) ambitionBias,
+            Func<Guid, int> opinionOf,
+            Func<Guid, Guid> factionOf,
+            PlannerConfig config)
+        {
+            Actor = actor;
+            ActorFactionId = actorFactionId;
+            FactionStatus = factionStatus;
+            ActorSystemId = actorSystemId;
+            SystemSecurity = systemSecurity;
+            ActorLeaderId = actorLeaderId;
+            SameFactionCharacters = sameFactionCharacters;
+            OtherFactionCharacters = otherFactionCharacters;
+            Captives = captives;
+            Ambition = ambition;
+            AmbitionBias = ambitionBias;
+            OpinionOf = opinionOf;
+            FactionOf = factionOf;
+            Config = config;
+        }
+    }
+}

--- a/Domain/Social/IntentModels.cs
+++ b/Domain/Social/IntentModels.cs
@@ -15,4 +15,12 @@ namespace SkyHorizont.Domain.Social
         Guid? TargetFactionId = null,
         Guid? TargetPlanetId = null
     );
+
+    /// <summary>Internal scoring container before conflict resolution.</summary>
+    public sealed record ScoredIntent(
+        IntentType Type,
+        double Score,
+        Guid? TargetCharacterId,
+        Guid? TargetFactionId,
+        Guid? TargetPlanetId);
 }

--- a/Domain/Social/PlannerConfig.cs
+++ b/Domain/Social/PlannerConfig.cs
@@ -1,0 +1,32 @@
+namespace SkyHorizont.Domain.Social
+{
+    public sealed class PlannerConfig
+    {
+        public int MaxIntentsPerMonth { get; init; } = 2;
+        public double ScoreNoiseMax { get; init; } = 5.0;
+        public double RomanceWeight { get; init; } = 0.9;
+        public double FamilyWeight { get; init; } = 0.7;
+        public double LoverVisitWeight { get; init; } = 1.0;
+        public double SpyWeight { get; init; } = 1.0;
+        public double BribeWeight { get; init; } = 0.8;
+        public double RecruitWeight { get; init; } = 0.9;
+        public double DefectionWeight { get; init; } = 1.0;
+        public double NegotiateWeight { get; init; } = 0.7;
+        public double QuarrelWeight { get; init; } = 0.6;
+        public double AssassinateWeight { get; init; } = 0.65;
+        public double TortureWeight { get; init; } = 0.75;
+        public double RapeWeight { get; init; } = 0.6;
+        public double TravelWeight { get; init; } = 0.8;
+        public double BecomePirateWeight { get; init; } = 0.9;
+        public double RaidConvoyWeight { get; init; } = 1.0;
+        public int MinBribeBudget { get; init; } = 200;
+        public double AssassinateFrequency { get; init; } = 0.05;
+        public int MaxCandidatePool { get; init; } = 60;
+        public int MaxCrossFactionPool { get; init; } = 40;
+        public int QuarrelOpinionThreshold { get; init; } = -25;
+        public int AssassinationOpinionThreshold { get; init; } = -50;
+        public int ConflictBuffer { get; init; } = 8;
+
+        public static PlannerConfig Default => new();
+    }
+}

--- a/Infrastructure/Social/IntentPlanner.cs
+++ b/Infrastructure/Social/IntentPlanner.cs
@@ -16,9 +16,9 @@ namespace SkyHorizont.Infrastructure.Social
         private readonly IRandomService _rng;
         private readonly IPlanetRepository _planets;
         private readonly IFleetRepository _fleets;
-        private readonly ITravelService _travel;
         private readonly IPiracyService _piracy;
         private readonly PlannerConfig _cfg;
+        private readonly IEnumerable<IIntentRule> _rules;
         private readonly Dictionary<Guid, FactionStatus> _factionStatusCache;
         private readonly Dictionary<Guid, SystemSecurity> _systemSecurityCache;
 
@@ -29,8 +29,8 @@ namespace SkyHorizont.Infrastructure.Social
             IRandomService rng,
             IPlanetRepository planets,
             IFleetRepository fleets,
-            ITravelService travel,
             IPiracyService piracy,
+            IEnumerable<IIntentRule> rules,
             PlannerConfig? config = null)
         {
             _chars = characters ?? throw new ArgumentNullException(nameof(characters));
@@ -39,8 +39,8 @@ namespace SkyHorizont.Infrastructure.Social
             _rng = rng ?? throw new ArgumentNullException(nameof(rng));
             _planets = planets ?? throw new ArgumentNullException(nameof(planets));
             _fleets = fleets ?? throw new ArgumentNullException(nameof(fleets));
-            _travel = travel ?? throw new ArgumentNullException(nameof(travel));
             _piracy = piracy ?? throw new ArgumentNullException(nameof(piracy));
+            _rules = rules ?? Enumerable.Empty<IIntentRule>();
             _cfg = config ?? PlannerConfig.Default;
             _factionStatusCache = new Dictionary<Guid, FactionStatus>();
             _systemSecurityCache = new Dictionary<Guid, SystemSecurity>();
@@ -74,94 +74,25 @@ namespace SkyHorizont.Infrastructure.Social
             var ambition = actor.Ambition ?? AssignAmbition(actor);
             var ambitionBias = GetAmbitionBias(ambition);
 
-            // Courtship
-            var romanticTarget = PickRomanticTarget(actor, sameFaction.Concat(otherFaction).Distinct().ToList(), GetFactionForCharacter, GetOpinionOfCharacter);
-            if (romanticTarget != null)
-                AddIfAboveZero(intents, ScoreCourtship(actor, romanticTarget, factionStatus, GetOpinionOfCharacter) * ambitionBias.Court, IntentType.Court, romanticTarget.Id);
+            var ctx = new IntentContext(
+                actor,
+                actorFactionId,
+                factionStatus,
+                actorSystemId,
+                systemSecurity,
+                actorLeaderId,
+                sameFaction,
+                otherFaction,
+                captives,
+                ambition,
+                ambitionBias,
+                GetOpinionOfCharacter,
+                GetFactionForCharacter,
+                _cfg);
 
-            // Family Visit
-            var familyTarget = PickFamilyTarget(actor, GetOpinionOfCharacter);
-            if (familyTarget.HasValue)
-                AddIfAboveZero(intents, ScoreVisitFamily(actor, familyTarget.Value, factionStatus, GetOpinionOfCharacter) * ambitionBias.Family, IntentType.VisitFamily, familyTarget.Value);
+            foreach (var rule in _rules)
+                intents.AddRange(rule.Generate(ctx));
 
-            // Visit Lover (works across factions)
-            var loverTarget = PickLoverTarget(actor);
-            if (loverTarget != null)
-                AddIfAboveZero(intents, ScoreVisitLover(actor, loverTarget, factionStatus, GetOpinionOfCharacter) * _cfg.LoverVisitWeight, IntentType.VisitLover, loverTarget.Id);
-            // Spy
-            var spyTargetFaction = PickSpyFaction(actorFactionId);
-            if (spyTargetFaction != Guid.Empty)
-                AddIfAboveZero(intents, ScoreSpy(actor, factionStatus) * ambitionBias.Spy, IntentType.Spy, null, spyTargetFaction);
-
-            var spyTargetChar = PickSpyCharacter(actorFactionId, otherFaction, GetFactionForCharacter, GetOpinionOfCharacter);
-            if (spyTargetChar != null)
-                AddIfAboveZero(intents, ScoreSpy(actor, factionStatus) * ambitionBias.Spy, IntentType.Spy, spyTargetChar.Id, null);
-
-            // Bribe
-            var bribeTarget = PickBribeTarget(otherFaction, GetOpinionOfCharacter);
-            if (bribeTarget != null)
-                AddIfAboveZero(intents, ScoreBribe(actor, bribeTarget, actorFactionId, factionStatus, GetFactionForCharacter) * ambitionBias.Bribe, IntentType.Bribe, bribeTarget.Id);
-
-            // Recruit
-            if (IsRecruiter(actor))
-            {
-                var recruitTarget = PickRecruitTarget(actorFactionId, otherFaction, GetFactionForCharacter);
-                if (recruitTarget != null)
-                    AddIfAboveZero(intents, ScoreRecruit(actor, recruitTarget, actorFactionId, factionStatus, GetFactionForCharacter) * ambitionBias.Recruit, IntentType.Recruit, recruitTarget.Id);
-            }
-
-            // Defection
-            if (actorLeaderId.HasValue)
-            {
-                var defectTargetFaction = PickDefectionFaction(actorFactionId);
-                if (defectTargetFaction != Guid.Empty)
-                    AddIfAboveZero(intents, ScoreDefect(actor, actorLeaderId.Value, actorFactionId, defectTargetFaction, factionStatus, GetOpinionOfCharacter) * ambitionBias.Defect, IntentType.Defect, null, defectTargetFaction);
-            }
-
-            // Negotiate
-            var negotiateTargetFaction = PickNegotiateFaction(actor, actorFactionId);
-            if (negotiateTargetFaction != Guid.Empty)
-                AddIfAboveZero(intents, ScoreNegotiate(actor, actorFactionId, negotiateTargetFaction, factionStatus) * ambitionBias.Negotiate, IntentType.Negotiate, null, negotiateTargetFaction);
-
-            // Quarrel
-            var quarrelTarget = PickQuarrelTarget(actor, otherFaction, GetOpinionOfCharacter);
-            if (quarrelTarget != null)
-                AddIfAboveZero(intents, ScoreQuarrel(actor, quarrelTarget, factionStatus, GetOpinionOfCharacter) * ambitionBias.Quarrel, IntentType.Quarrel, quarrelTarget.Id);
-
-            // Assassinate
-            var assassinateTarget = PickAssassinationTarget(otherFaction, GetOpinionOfCharacter);
-            if (assassinateTarget != null)
-                AddIfAboveZero(intents, ScoreAssassinate(actor, assassinateTarget, actorFactionId, factionStatus, GetFactionForCharacter, GetOpinionOfCharacter) * ambitionBias.Assassinate, IntentType.Assassinate, assassinateTarget.Id);
-
-            // Torture
-            var tortureTarget = PickTortureTarget(captives, GetOpinionOfCharacter);
-            if (tortureTarget != null)
-                AddIfAboveZero(intents, ScoreTorture(actor, tortureTarget, actorFactionId, factionStatus, GetFactionForCharacter, GetOpinionOfCharacter) * ambitionBias.Torture, IntentType.TorturePrisoner, tortureTarget.Id);
-
-            // Rape
-            var rapeTarget = PickRapeTarget(captives, GetOpinionOfCharacter);
-            if (rapeTarget != null)
-                AddIfAboveZero(intents, ScoreRape(actor, rapeTarget, actorFactionId, factionStatus, GetFactionForCharacter, GetOpinionOfCharacter) * ambitionBias.Rape, IntentType.RapePrisoner, rapeTarget.Id);
-
-            // Travel
-            var travelDest = PickTravelDestinationPlanet(actor, actorFactionId, systemSecurity, GetFactionForCharacter, GetOpinionOfCharacter);
-            if (travelDest.HasValue)
-                AddIfAboveZero(intents, ScoreTravel(actor, travelDest.Value, factionStatus, systemSecurity) * ambitionBias.Travel, IntentType.TravelToPlanet, targetPlanetId: travelDest.Value);
-
-            // Become Pirate
-            if (!_piracy.IsPirateFaction(actorFactionId))
-            {
-                var pirateScore = ScoreBecomePirate(actor, actorFactionId, actorLeaderId, systemSecurity, GetOpinionOfCharacter);
-                AddIfAboveZero(intents, pirateScore * ambitionBias.BecomePirate, IntentType.BecomePirate);
-            }
-
-            // Raid Convoy
-            if (_piracy.IsPirateFaction(actorFactionId))
-            {
-                var raidTargetSystem = PickRaidTargetSystem(actorSystemId, actorFactionId);
-                if (raidTargetSystem.HasValue)
-                    AddIfAboveZero(intents, ScoreRaidConvoy(actor, raidTargetSystem.Value, systemSecurity) * ambitionBias.RaidConvoy, IntentType.RaidConvoy, targetFactionId: raidTargetSystem.Value);
-            }
 
             if (intents.Count == 0)
                 return Enumerable.Empty<CharacterIntent>();
@@ -195,627 +126,6 @@ namespace SkyHorizont.Infrastructure.Social
                 { CharacterAmbition.SeekAdventure, actor.Skills.Intelligence * 0.3 + actor.Personality.Openness * 0.3 + PersonalityTraits.GetTraitEffect("ThrillSeeker", actor.Personality) }
             };
             return scores.OrderByDescending(kv => kv.Value + _rng.NextDouble() * 5).First().Key;
-        }
-
-        private double ScoreCourtship(Character actor, Character target, FactionStatus factionStatus, Func<Guid, int> opin)
-        {
-            var opinion = opin(target.Id);
-            var baseScore = 0.0;
-
-            baseScore += Clamp0to100Map(actor.Personality.CheckCompatibility(target.Personality));
-            baseScore += Clamp0to100Map(Math.Max(0, opinion + 50));
-
-            var traits = PersonalityTraits.GetActiveTraits(actor.Personality);
-            foreach (var (traitName, intensity) in traits["Extraversion"].Concat(traits["Agreeableness"]))
-                baseScore += PersonalityTraits.GetTraitEffect(traitName, actor.Personality);
-
-            if (actor.Relationships.Any(r => r.Type == RelationshipType.Lover || r.Type == RelationshipType.Spouse))
-                baseScore += 15;
-
-            if (actor.Personality.Extraversion < 40) baseScore -= 10;
-            if (factionStatus.HasAlliance) baseScore += 10;
-
-            return Clamp0to100(baseScore * _cfg.RomanceWeight);
-        }
-
-        private double ScoreVisitFamily(Character actor, Guid familyId, FactionStatus factionStatus, Func<Guid, int> opin)
-        {
-            var opinion = opin(familyId);
-            var baseScore = 30.0
-                + Clamp0to100Map(opinion + 50)
-                + (actor.Personality.Agreeableness - 50) * 0.3
-                + (actor.Personality.Conscientiousness - 50) * 0.2;
-
-            if (factionStatus.HasUnrest)
-                baseScore += 10;
-            return Clamp0to100(baseScore * _cfg.FamilyWeight);
-        }
-
-        private double ScoreVisitLover(Character actor, Character lover, FactionStatus factionStatus, Func<Guid, int> opin)
-        {
-            var opinion = opin(lover.Id);
-            double baseScore = 35.0;
-
-            // liking + personality nudges
-            baseScore += Clamp0to100Map(opinion + 50) * 0.5;
-            baseScore += (actor.Personality.Agreeableness - 50) * 0.25;
-            baseScore += (actor.Personality.Extraversion - 50) * 0.20;
-
-            // traits that help spending time/affection
-            var traits = PersonalityTraits.GetActiveTraits(actor.Personality);
-            foreach (var (traitName, intensity) in traits["Agreeableness"].Concat(traits["Extraversion"]))
-                baseScore += PersonalityTraits.GetTraitEffect(traitName, actor.Personality) * 0.6;
-
-            // cross‑faction relationships want visits even more
-            var actorFactionId = _factions.GetFactionIdForCharacter(actor.Id);
-            var loverFactionId = _factions.GetFactionIdForCharacter(lover.Id);
-            if (actorFactionId != Guid.Empty && loverFactionId != Guid.Empty && actorFactionId != loverFactionId)
-                baseScore += 15;
-
-            // alliances make it easier/logistically safer
-            if (_factions.HasAlliance(actorFactionId, loverFactionId))
-                baseScore += 10;
-
-            // unrest increases desire to check in
-            if (factionStatus.HasUnrest)
-                baseScore += 5;
-
-            return Clamp0to100(baseScore);
-        }
-
-        private double ScoreSpy(Character actor, FactionStatus factionStatus)
-        {
-            var baseScore = actor.Skills.Intelligence * 0.6;
-
-            var traits = PersonalityTraits.GetActiveTraits(actor.Personality);
-            foreach (var (traitName, intensity) in traits["Openness"].Concat(traits["Neuroticism"]))
-                baseScore += PersonalityTraits.GetTraitEffect(traitName, actor.Personality);
-
-            baseScore += (int)actor.Rank * 2;
-            if (actor.Rank == Rank.Civilian && actor.Skills.Intelligence < 65) baseScore -= 15;
-            if (factionStatus.IsAtWar) baseScore += 15;
-
-            return Clamp0to100(baseScore * _cfg.SpyWeight);
-        }
-
-        private double ScoreBribe(Character actor, Character target, Guid actorFactionId, FactionStatus factionStatus, Func<Guid, Guid> fac)
-        {
-            var baseScore = 20.0;
-            var hardness = (target.Personality.Conscientiousness + target.Personality.Agreeableness) / 2.0;
-            baseScore += (100 - hardness) * 0.4;
-            baseScore -= (actor.Personality.Conscientiousness - 50) * 0.2;
-            baseScore -= (actor.Personality.Agreeableness - 50) * 0.2;
-            var targetFaction = fac(target.Id);
-            if (_factions.IsAtWar(actorFactionId, targetFaction)) baseScore += 10;
-            if (factionStatus.EconomyWeak) baseScore += 10;
-            if (actor.Balance < _cfg.MinBribeBudget) baseScore -= 25;
-
-            return Clamp0to100(baseScore * _cfg.BribeWeight);
-        }
-
-        private double ScoreRecruit(Character actor, Character target, Guid actorFactionId, FactionStatus factionStatus, Func<Guid, Guid> fac)
-        {
-            var baseScore = 30.0;
-
-            var talent = (target.Skills.Military + target.Skills.Intelligence + target.Skills.Economy + target.Skills.Research) / 4.0;
-            baseScore += talent * 0.4;
-            baseScore += (int)actor.Rank * 3;
-            baseScore += (actor.Personality.Agreeableness - 50) * 0.2;
-            baseScore += (actor.Personality.Extraversion - 50) * 0.2;
-
-            var targetFactionId = fac(target.Id);
-            var sameFaction = actorFactionId == targetFactionId;
-            if (sameFaction)
-                baseScore -= 10;
-            if (factionStatus.HasUnrest)
-                baseScore += 10;
-
-            try
-            {
-                int opinion = _opinions.GetOpinion(actor.Id, target.Id);
-                baseScore += Math.Clamp(opinion, -50, 50) * 0.10;
-            }
-            catch {  }
-
-            if (_piracy.IsPirateFaction(actorFactionId))
-            {
-                if (target.Rank >= Rank.General)
-                    baseScore -= 10;
-                var isGovernor = _planets.GetAll().Any(p => p.GovernorId == target.Id);
-                if (isGovernor)
-                    baseScore -= 15;
-            }
-
-            return Clamp0to100(baseScore * _cfg.RecruitWeight);
-        }
-
-
-        private double ScoreDefect(Character actor, Guid leaderId, Guid actorFactionId, Guid targetFactionId, FactionStatus factionStatus, Func<Guid, int> opin)
-        {
-            var opinionLeader = opin(leaderId);
-            var baseScore = Clamp0to100Map(-opinionLeader) * 0.8;
-            baseScore += (50 - actor.Personality.Conscientiousness) * 0.2;
-            baseScore += (50 - actor.Personality.Agreeableness) * 0.2;
-            baseScore += (actor.Personality.Openness - 50) * 0.15;
-            baseScore -= (actor.Personality.Neuroticism - 50) * 0.15;
-            if (_factions.IsAtWar(actorFactionId, targetFactionId)) baseScore += 10;
-            if (factionStatus.HasUnrest) baseScore += 15;
-            baseScore -= (int)actor.Rank * 2;
-
-            return Clamp0to100(baseScore * _cfg.DefectionWeight);
-        }
-
-        private double ScoreNegotiate(Character actor, Guid myFactionId, Guid targetFactionId, FactionStatus factionStatus)
-        {
-            var baseScore = 25.0;
-            baseScore += (actor.Personality.Agreeableness - 50) * 0.3;
-            baseScore += (actor.Personality.Extraversion - 50) * 0.2;
-            var traits = PersonalityTraits.GetActiveTraits(actor.Personality);
-            foreach (var (traitName, intensity) in traits["Agreeableness"].Concat(traits["Extraversion"]))
-                baseScore += PersonalityTraits.GetTraitEffect(traitName, actor.Personality);
-            if (_factions.IsAtWar(myFactionId, targetFactionId)) baseScore += 10;
-            if (factionStatus.EconomyWeak) baseScore += 10;
-            baseScore += (int)actor.Rank * 3;
-
-            return Clamp0to100(baseScore * _cfg.NegotiateWeight);
-        }
-
-        private double ScoreQuarrel(Character actor, Character target, FactionStatus factionStatus, Func<Guid, int> opin)
-        {
-            var opinion = opin(target.Id);
-            var baseScore = 0.0;
-            if (opinion < _cfg.QuarrelOpinionThreshold)
-                baseScore += Clamp0to100Map(_cfg.QuarrelOpinionThreshold - opinion);
-            var traits = PersonalityTraits.GetActiveTraits(actor.Personality);
-            foreach (var (traitName, intensity) in traits["Neuroticism"])
-                baseScore += PersonalityTraits.GetTraitEffect(traitName, actor.Personality);
-            if ((int)target.Rank > (int)actor.Rank) baseScore -= 10;
-            if (factionStatus.HasUnrest) baseScore += 10;
-
-            return Clamp0to100(baseScore * _cfg.QuarrelWeight);
-        }
-
-        private double ScoreAssassinate(Character actor, Character target, Guid actorFactionId, FactionStatus factionStatus, Func<Guid, Guid> fac, Func<Guid, int> opin)
-        {
-            var opinion = opin(target.Id);
-            var baseScore = 0.0;
-            baseScore += actor.Skills.Military * 0.4;
-            baseScore += Math.Max(0, -opinion) * 0.2;
-            var traits = PersonalityTraits.GetActiveTraits(actor.Personality);
-            foreach (var (traitName, intensity) in traits["Neuroticism"].Concat(traits["Extraversion"]))
-                baseScore += PersonalityTraits.GetTraitEffect(traitName, actor.Personality);
-            baseScore += PersonalityTraits.GetTraitCombinationEffect("ImpulsiveAnger", actor.Personality);
-            baseScore -= (actor.Personality.Conscientiousness - 50) * 0.2;
-            baseScore -= (actor.Personality.Agreeableness - 50) * 0.2;
-            var targetFaction = fac(target.Id);
-            if (_factions.IsAtWar(actorFactionId, targetFaction)) baseScore += 20;
-            if (factionStatus.HasUnrest) baseScore += 10;
-            if (actor.Rank <= Rank.Captain && actor.Skills.Military < 70) baseScore -= 20;
-            baseScore -= 15;
-
-            return Clamp0to100(baseScore * _cfg.AssassinateWeight);
-        }
-
-        private double ScoreTorture(Character actor, Character target, Guid actorFactionId, FactionStatus factionStatus, Func<Guid, Guid> fac, Func<Guid, int> opin)
-        {
-            var opinion = opin(target.Id);
-            var baseScore = 0.0;
-            baseScore += (50 - actor.Personality.Agreeableness) * 0.4;
-            baseScore += (actor.Personality.Conscientiousness - 50) * 0.2;
-            baseScore += (int)target.Rank * 5;
-            baseScore += target.Skills.Intelligence * 0.3;
-            if (opinion < 0) baseScore += Clamp0to100Map(-opinion) * 0.5;
-            var traits = PersonalityTraits.GetActiveTraits(actor.Personality);
-            foreach (var (traitName, intensity) in traits["Neuroticism"])
-                baseScore += PersonalityTraits.GetTraitEffect(traitName, actor.Personality);
-            baseScore += PersonalityTraits.GetTraitCombinationEffect("ImpulsiveAnger", actor.Personality);
-            var targetFaction = fac(target.Id);
-            if (_factions.IsAtWar(actorFactionId, targetFaction)) baseScore += 15;
-            if (factionStatus.IsAtWar) baseScore += 10;
-            baseScore += (int)actor.Rank * 3;
-            if (actor.Rank < Rank.Captain) baseScore -= 20;
-
-            return Clamp0to100(baseScore * _cfg.TortureWeight);
-        }
-
-        private double ScoreRape(Character actor, Character target, Guid actorFactionId, FactionStatus factionStatus, Func<Guid, Guid> fac, Func<Guid, int> opin)
-        {
-            var opinion = opin(target.Id);
-            var baseScore = 0.0;
-            baseScore += (50 - actor.Personality.Agreeableness) * 0.5;
-            baseScore += (50 - actor.Personality.Conscientiousness) * 0.3;
-            if (opinion < 0) baseScore += Clamp0to100Map(-opinion) * 0.6;
-            var traits = PersonalityTraits.GetActiveTraits(actor.Personality);
-            foreach (var (traitName, intensity) in traits["Neuroticism"].Concat(traits["Extraversion"]))
-                baseScore += PersonalityTraits.GetTraitEffect(traitName, actor.Personality);
-            baseScore += PersonalityTraits.GetTraitCombinationEffect("ImpulsiveAnger", actor.Personality);
-            var targetFaction = fac(target.Id);
-            if (_factions.IsAtWar(actorFactionId, targetFaction)) baseScore += 15;
-            if (factionStatus.HasUnrest) baseScore += 5;
-            baseScore += (int)actor.Rank * 2;
-            baseScore -= (actor.Personality.Neuroticism - 50) * 0.2;
-            if (actor.Rank < Rank.Captain) baseScore -= 25;
-
-            return Clamp0to100(baseScore * _cfg.RapeWeight);
-        }
-
-        private double ScoreTravel(Character actor, Guid destinationPlanetId, FactionStatus factionStatus, SystemSecurity? systemSecurity)
-        {
-            var baseScore = 20.0;
-            baseScore += (actor.Personality.Extraversion - 50) * 0.3;
-            baseScore += (actor.Personality.Openness - 50) * 0.3;
-            var traits = PersonalityTraits.GetActiveTraits(actor.Personality);
-            foreach (var (traitName, intensity) in traits["Extraversion"].Concat(traits["Openness"]))
-                baseScore += PersonalityTraits.GetTraitEffect(traitName, actor.Personality);
-            var destPlanet = _planets.GetById(destinationPlanetId);
-            if (destPlanet != null && destPlanet.UnrestLevel > 50)
-                baseScore -= 10; 
-            if (factionStatus.HasAlliance && _factions.GetFactionIdForPlanet(destinationPlanetId) == _factions.GetFactionIdForCharacter(actor.Id))
-                baseScore += 15;
-            if (systemSecurity != null && systemSecurity.PirateActivity > 50)
-                baseScore -= systemSecurity.PirateActivity * 0.1;
-
-            return Clamp0to100(baseScore * _cfg.TravelWeight);
-        }
-
-        private double ScoreBecomePirate(Character actor, Guid actorFactionId, Guid? actorLeaderId, SystemSecurity? systemSecurity, Func<Guid, int> opin)
-        {
-            // Hard filters first
-            var planets = _planets.GetPlanetsControlledByFaction(actorFactionId);
-            var IsGovernor = false;
-            foreach (var planet in planets)
-            {
-                if (planet.GovernorId == actor.Id)
-                {
-                    IsGovernor = false;
-                    break;
-                }
-            }
-            if (IsGovernor || actor.Rank >= Rank.General || actor.Balance > 2000)
-                    return 0;
-            
-            double baseScore = 0.0;
-
-            if (actorLeaderId.HasValue)
-                baseScore += Clamp0to100Map(Math.Max(0, -opin(actorLeaderId.Value)));
-
-            baseScore += (50 - actor.Personality.Conscientiousness) * 0.3;
-            baseScore += (50 - actor.Personality.Agreeableness) * 0.3;
-            baseScore += PersonalityTraits.GetTraitEffect("ThrillSeeker", actor.Personality);
-
-            if (actor.Balance < 500)
-                baseScore += 20;
-            else if (actor.Balance < 1000)
-                baseScore += 10;
-
-            if (systemSecurity != null)
-            {
-                baseScore += systemSecurity.PirateActivity * 0.2;
-                baseScore -= systemSecurity.PatrolStrength * 0.1;
-            }
-
-            if (GetFactionStatus(actorFactionId).HasUnrest)
-                baseScore += 15;
-
-            return Clamp0to100(baseScore * _cfg.BecomePirateWeight);
-        }
-
-
-        private double ScoreRaidConvoy(Character actor, Guid systemId, SystemSecurity? systemSecurity)
-        {
-            var baseScore = 0.0;
-            baseScore += (actor.Skills.Military - 50) * 0.4;
-            baseScore += (50 - actor.Personality.Agreeableness) * 0.2;
-            var traits = PersonalityTraits.GetActiveTraits(actor.Personality);
-            foreach (var (traitName, intensity) in traits["Extraversion"].Concat(traits["Neuroticism"]))
-                baseScore += PersonalityTraits.GetTraitEffect(traitName, actor.Personality);
-            baseScore += PersonalityTraits.GetTraitCombinationEffect("ImpulsiveAnger", actor.Personality);
-            if (systemSecurity != null)
-            {
-                baseScore += systemSecurity.PirateActivity * 0.4;
-                baseScore += systemSecurity.Traffic * 0.3;
-                baseScore -= systemSecurity.PatrolStrength * 0.2;
-            }
-            return Clamp0to100(baseScore * _cfg.RaidConvoyWeight);
-        }
-
-        private Guid? PickTravelDestinationPlanet(Character actor, Guid actorFactionId, SystemSecurity? systemSecurity, Func<Guid, Guid> fac, Func<Guid, int> opin)
-        {
-            var currentPlanetId = GetCharacterPlanetId(actor.Id);
-            if (!currentPlanetId.HasValue) return null;
-
-            var loved = actor.Relationships
-                .Where(r => r.Type == RelationshipType.Lover || r.Type == RelationshipType.Spouse)
-                .Select(r => r.TargetCharacterId)
-                .Concat(actor.FamilyLinkIds)
-                .Distinct()
-                .ToList();
-
-            var alliedPlanets = _planets.GetAll()
-                .Where(p => fac(p.FactionId) == actorFactionId || _factions.HasAlliance(actorFactionId, p.FactionId))
-                .ToList();
-
-            var pool = _planets.GetAll()
-                .Where(p => p.Id != currentPlanetId.Value)
-                .Select(p => new
-                {
-                    Planet = p,
-                    Score = (loved.Any(id => p.Citizens.Contains(id) || p.Prisoners.Contains(id)) ? 50 : 0) +
-                            (fac(p.FactionId) == actorFactionId ? 20 : 0) +
-                            (_factions.HasAlliance(actorFactionId, p.FactionId) ? 15 : 0) +
-                            (p.IsTradeHub ? 10 : 0) -
-                            (p.UnrestLevel > 50 ? p.UnrestLevel * 0.1 : 0) +
-                            _rng.NextInt(0, 20)
-                })
-                .OrderByDescending(x => x.Score)
-                .Take(5) // Limit to top 5 candidates
-                .ToList();
-
-            return pool.Count > 0 ? pool[_rng.NextInt(0, pool.Count)].Planet.Id : null;
-        }
-
-        private Guid? PickRaidTargetSystem(Guid? actorSystemId, Guid actorFactionId)
-        {
-            if (!actorSystemId.HasValue) return null;
-            var systems = _planets.GetAll()
-                .GroupBy(p => p.SystemId)
-                .Select(g => new
-                {
-                    SystemId = g.Key,
-                    Traffic = _piracy.GetTrafficLevel(g.Key),
-                    PirateActivity = _piracy.GetPirateActivity(g.Key),
-                    PatrolStrength = GetSystemSecurity(g.Key).PatrolStrength
-                })
-                .Where(s => s.SystemId != actorSystemId.Value && !_piracy.IsPirateFaction(_factions.GetFactionIdForSystem(s.SystemId)))
-                .OrderByDescending(s => s.Traffic * 0.5 + s.PirateActivity * 0.3 - s.PatrolStrength * 0.2)
-                .Take(3) // Limit to top 3 systems
-                .ToList();
-
-            return systems.Count > 0 ? systems[_rng.NextInt(0, systems.Count)].SystemId : null;
-        }
-
-        private Guid? GetCharacterPlanetId(Guid characterId)
-        {
-            foreach (var p in _planets.GetAll())
-                if (p.Citizens.Contains(characterId) || p.Prisoners.Contains(characterId))
-                    return p.Id;
-            return null;
-        }
-
-        private Guid? GetCharacterSystemId(Guid characterId)
-        {
-            foreach (var p in _planets.GetAll())
-                if (p.Citizens.Contains(characterId) || p.Prisoners.Contains(characterId))
-                    return p.SystemId;
-            foreach (var f in _fleets.GetAll())
-                if (f.AssignedCharacterId == characterId || f.Prisoners.Contains(characterId))
-                    return f.CurrentSystemId;
-            return null;
-        }
-
-        private FactionStatus GetFactionStatus(Guid factionId)
-        {
-            if (_factionStatusCache.TryGetValue(factionId, out var status))
-                return status;
-
-            var isAtWar = _factions.GetAllRivalFactions(factionId).Any(f => _factions.IsAtWar(factionId, f));
-            var hasAlliance = _factions.GetAllRivalFactions(factionId).Any(f => _factions.HasAlliance(factionId, f));
-            var hasUnrest = _planets.GetPlanetsControlledByFaction(factionId).Any(p => p.UnrestLevel > 50);
-            var economyWeak = _factions.GetEconomicStrength(factionId) < 50;
-
-            status = new FactionStatus(isAtWar, hasAlliance, hasUnrest, economyWeak);
-            _factionStatusCache[factionId] = status;
-            return status;
-        }
-
-        private SystemSecurity GetSystemSecurity(Guid systemId)
-        {
-            if (_systemSecurityCache.TryGetValue(systemId, out var security))
-                return security;
-
-            var securityLevel = _piracy.GetPirateActivity(systemId);
-            var traffic = _piracy.GetTrafficLevel(systemId);
-            var patrolStrength = _planets.GetAll()
-                .Where(p => p.SystemId == systemId)
-                .Sum(p => p.BaseDefense);
-
-            security = new SystemSecurity(systemId, 0, securityLevel, traffic); // ToDo: patrolls?
-            _systemSecurityCache[systemId] = security;
-            return security;
-        }
-
-        private (double Court, double Family, double Spy, double Bribe, double Recruit, double Defect, double Negotiate, double Quarrel, double Assassinate, double Torture, double Rape, double Travel, double BecomePirate, double RaidConvoy) GetAmbitionBias(CharacterAmbition ambition)
-        {
-            return ambition switch
-            {
-                CharacterAmbition.GainPower => (0.8, 0.7, 1.2, 1.1, 1.2, 1.3, 1.0, 1.0, 1.3, 1.0, 0.9, 0.8, 0.9, 0.8),
-                CharacterAmbition.BuildWealth => (0.9, 0.8, 1.1, 1.3, 1.1, 0.8, 1.2, 0.7, 0.8, 0.7, 0.6, 1.0, 1.2, 1.3),
-                CharacterAmbition.EnsureFamilyLegacy => (1.2, 1.3, 0.8, 0.9, 0.9, 0.7, 0.9, 0.8, 0.7, 0.6, 0.5, 1.1, 0.7, 0.6),
-                CharacterAmbition.SeekAdventure => (0.9, 0.8, 1.2, 0.9, 0.9, 1.0, 0.9, 1.0, 1.0, 0.8, 0.7, 1.3, 1.2, 1.2),
-                _ => (1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0)
-            };
-        }
-
-        private Character? PickRomanticTarget(Character actor, List<Character> candidates, Func<Guid, Guid> fac, Func<Guid, int> opin)
-        {
-            var lovers = actor.Relationships.Where(r => r.Type == RelationshipType.Lover || r.Type == RelationshipType.Spouse)
-                                            .Select(r => r.TargetCharacterId)
-                                            .ToHashSet();
-            var known = candidates.Where(c => lovers.Contains(c.Id)).ToList();
-            if (known.Count > 0) return known[_rng.NextInt(0, known.Count)];
-            var myFaction = fac(actor.Id);
-            var pool = candidates.Where(c => fac(c.Id) == myFaction).ToList();
-            if (pool.Count == 0) return null;
-            return pool.Select(c => new
-            {
-                C = c,
-                Score = 0.6 * opin(c.Id) + 0.4 * actor.Personality.CheckCompatibility(c.Personality)
-            })
-            .OrderByDescending(x => x.Score)
-            .FirstOrDefault()?.C;
-        }
-
-        private Guid? PickFamilyTarget(Character actor, Func<Guid, int> opin)
-        {
-            if (actor.FamilyLinkIds.Count == 0) return null;
-            var weighted = actor.FamilyLinkIds
-                .Select(fid => new { Id = fid, W = opin(fid) + 60 + _rng.NextInt(0, 20) })
-                .OrderByDescending(x => x.W)
-                .FirstOrDefault();
-            return weighted?.Id;
-        }
-
-        private Character? PickLoverTarget(Character actor)
-        {
-            if (actor.Relationships.Count == 0)
-                return null;
-
-            var loverIds = actor.Relationships
-                .Where(r => r.Type == RelationshipType.Lover || r.Type == RelationshipType.Spouse)
-                .Select(r => r.TargetCharacterId)
-                .ToHashSet();
-
-            if (loverIds.Count == 0)
-                return null;
-
-            var lovers = _chars.GetByIds(loverIds).Where(c => c.IsAlive).ToList();
-            if (lovers.Count == 0)
-                return null;
-
-            // prefer stable/high-opinion partner
-            return lovers
-                .Select(c => new { C = c, O = _opinions.GetOpinion(actor.Id, c.Id) + _rng.NextInt(0, 10) })
-                .OrderByDescending(x => x.O)
-                .First().C;
-        }
-
-
-        private Guid PickSpyFaction(Guid actorFactionId)
-        {
-            var rivals = _factions.GetAllRivalFactions(actorFactionId).ToList();
-            if (rivals.Count == 0) return Guid.Empty;
-            var war = rivals.Where(f => _factions.IsAtWar(actorFactionId, f)).ToList();
-            if (war.Count > 0) return war[_rng.NextInt(0, war.Count)];
-            return rivals[_rng.NextInt(0, rivals.Count)];
-        }
-
-        private Character? PickBribeTarget(List<Character> otherFaction, Func<Guid, int> opin)
-        {
-            var pool = otherFaction
-                .Where(c => opin(c.Id) > -50)
-                .ToList();
-            if (pool.Count == 0) return null;
-            return pool.Select(c => new
-            {
-                C = c,
-                Score = (100 - c.Personality.Conscientiousness) + (100 - c.Personality.Agreeableness) + _rng.NextInt(0, 20)
-            })
-            .OrderByDescending(x => x.Score)
-            .First().C;
-        }
-
-        private bool IsRecruiter(Character actor) => actor.Rank >= Rank.Captain || actor.Skills.Military >= 70;
-
-        private Character? PickRecruitTarget(Guid actorFactionId, List<Character> candidates, Func<Guid, Guid> fac)
-        {
-            var pool = candidates.Where(c => fac(c.Id) != actorFactionId).ToList();
-            if (pool.Count == 0) return null;
-            return pool.Select(c => new
-            {
-                C = c,
-                Talent = (c.Skills.Military + c.Skills.Intelligence + c.Skills.Economy + c.Skills.Research) / 4.0
-            })
-            .OrderByDescending(x => x.Talent + _rng.NextInt(0, 10))
-            .First().C;
-        }
-
-        private Guid PickDefectionFaction(Guid actorFactionId)
-        {
-            var rivals = _factions.GetAllRivalFactions(actorFactionId).ToList();
-            if (rivals.Count == 0) return Guid.Empty;
-            var war = rivals.Where(f => _factions.IsAtWar(actorFactionId, f)).ToList();
-            if (war.Count > 0) return war[_rng.NextInt(0, war.Count)];
-            return rivals[_rng.NextInt(0, rivals.Count)];
-        }
-
-        private Guid PickNegotiateFaction(Character actor, Guid actorFactionId)
-        {
-            var rivals = _factions.GetAllRivalFactions(actorFactionId).ToList();
-            if (rivals.Count == 0) return Guid.Empty;
-            if (PersonalityTraits.Cheerful(actor.Personality) || PersonalityTraits.Trusting(actor.Personality))
-            {
-                var war = rivals.Where(f => _factions.IsAtWar(actorFactionId, f)).ToList();
-                if (war.Count > 0) return war[_rng.NextInt(0, war.Count)];
-            }
-            return rivals[_rng.NextInt(0, rivals.Count)];
-        }
-
-        private Character? PickQuarrelTarget(Character actor, List<Character> candidates, Func<Guid, int> opin)
-        {
-            var negatives = candidates
-                .Select(c => new { C = c, O = opin(c.Id) })
-                .Where(x => x.O < _cfg.QuarrelOpinionThreshold)
-                .OrderBy(x => x.O)
-                .ToList();
-            if (negatives.Count == 0) return null;
-            return negatives[_rng.NextInt(0, Math.Min(3, negatives.Count))].C;
-        }
-
-        private Character? PickAssassinationTarget(List<Character> otherFaction, Func<Guid, int> opin)
-        {
-            if (_rng.NextDouble() > _cfg.AssassinateFrequency) return null;
-            var pool = otherFaction
-                .Select(c => new { C = c, O = opin(c.Id) })
-                .Where(x => x.O < _cfg.AssassinationOpinionThreshold && x.C.Rank >= Rank.Major)
-                .OrderBy(x => x.O)
-                .ToList();
-            if (pool.Count == 0) return null;
-            return pool.First().C;
-        }
-
-        private Character? PickSpyCharacter(Guid actorFactionId, List<Character> candidates, Func<Guid, Guid> fac, Func<Guid, int> opin)
-        {
-            var pool = candidates
-                .Where(c => fac(c.Id) != actorFactionId)
-                .Select(c => new
-                {
-                    C = c,
-                    Score = (int)c.Rank * 10 - opin(c.Id) + _rng.NextInt(0, 10)
-                })
-                .OrderByDescending(x => x.Score)
-                .ToList();
-
-            return pool.Count == 0 ? null : pool.First().C;
-        }
-
-        private Character? PickTortureTarget(List<Character> captives, Func<Guid, int> opin)
-        {
-            if (captives.Count == 0) return null;
-            var pool = captives
-                .Select(c => new
-                {
-                    C = c,
-                    Score = (int)c.Rank * 10 + c.Skills.Intelligence + _rng.NextInt(0, 20)
-                })
-                .OrderByDescending(x => x.Score)
-                .ToList();
-            return pool.First().C;
-        }
-
-        private Character? PickRapeTarget(List<Character> captives, Func<Guid, int> opin)
-        {
-            if (captives.Count == 0)
-                return null;
-            var pool = captives
-                .Select(c => new
-                {
-                    C = c,
-                    Score = -opin(c.Id) + _rng.NextInt(0, 30)
-                })
-                .Where(x => x.Score > 0)
-                .OrderByDescending(x => x.Score)
-                .ToList();
-            return pool.Count == 0 ? null : pool.First().C;
         }
 
         private (List<Character> sameFaction, List<Character> otherFaction, List<Character> captives) SelectRelevantCharacters(
@@ -862,41 +172,58 @@ namespace SkyHorizont.Infrastructure.Social
             return (sameFaction, otherFaction, captives);
         }
 
-        private static void AddIfAboveZero(List<ScoredIntent> list, double score, IntentType type,
-                                           Guid? targetCharacterId = null, Guid? targetFactionId = null, Guid? targetPlanetId = null)
+        private Guid? GetCharacterSystemId(Guid characterId)
         {
-            if (score <= 0) return;
-            list.Add(new ScoredIntent(type, score, targetCharacterId, targetFactionId, targetPlanetId));
+            foreach (var p in _planets.GetAll())
+                if (p.Citizens.Contains(characterId) || p.Prisoners.Contains(characterId))
+                    return p.SystemId;
+            foreach (var f in _fleets.GetAll())
+                if (f.AssignedCharacterId == characterId || f.Prisoners.Contains(characterId))
+                    return f.CurrentSystemId;
+            return null;
         }
 
-        private static double Clamp0to100Map(double v) => Math.Clamp(v, 0, 100);
-        private static double Clamp0to100(double v) => v < 0 ? 0 : (v > 100 ? 100 : v);
-
-        private sealed record ScoredIntent(IntentType Type, double Score, Guid? TargetCharacterId, Guid? TargetFactionId, Guid? TargetPlanetId);
-
-        private static IEnumerable<CharacterIntent> FilterConflicts(IEnumerable<CharacterIntent> intents, Func<CharacterIntent, double> scoreOf)
+        private FactionStatus GetFactionStatus(Guid factionId)
         {
-            var conflictSets = new[]
-            {
-                new HashSet<IntentType> { IntentType.Court, IntentType.Assassinate },
-                new HashSet<IntentType> { IntentType.Negotiate, IntentType.Quarrel },
-                new HashSet<IntentType> { IntentType.Bribe, IntentType.Recruit },
-                new HashSet<IntentType> { IntentType.TorturePrisoner, IntentType.Negotiate },
-                new HashSet<IntentType> { IntentType.RapePrisoner, IntentType.Negotiate },
-                new HashSet<IntentType> { IntentType.TravelToPlanet, IntentType.RaidConvoy },
-                new HashSet<IntentType> { IntentType.Court, IntentType.VisitLover },
-            };
+            if (_factionStatusCache.TryGetValue(factionId, out var status))
+                return status;
 
-            var chosen = intents.ToList();
-            foreach (var set in conflictSets)
+            var isAtWar = _factions.GetAllRivalFactions(factionId).Any(f => _factions.IsAtWar(factionId, f));
+            var hasAlliance = _factions.GetAllRivalFactions(factionId).Any(f => _factions.HasAlliance(factionId, f));
+            var hasUnrest = _planets.GetPlanetsControlledByFaction(factionId).Any(p => p.UnrestLevel > 50);
+            var economyWeak = _factions.GetEconomicStrength(factionId) < 50;
+
+            status = new FactionStatus(isAtWar, hasAlliance, hasUnrest, economyWeak);
+            _factionStatusCache[factionId] = status;
+            return status;
+        }
+
+        private SystemSecurity GetSystemSecurity(Guid systemId)
+        {
+            if (_systemSecurityCache.TryGetValue(systemId, out var security))
+                return security;
+
+            var securityLevel = _piracy.GetPirateActivity(systemId);
+            var traffic = _piracy.GetTrafficLevel(systemId);
+            var patrolStrength = _planets.GetAll()
+                .Where(p => p.SystemId == systemId)
+                .Sum(p => p.BaseDefense);
+
+            security = new SystemSecurity(systemId, (int)patrolStrength, securityLevel, traffic);
+            _systemSecurityCache[systemId] = security;
+            return security;
+        }
+
+        private (double Court, double Family, double Spy, double Bribe, double Recruit, double Defect, double Negotiate, double Quarrel, double Assassinate, double Torture, double Rape, double Travel, double BecomePirate, double RaidConvoy) GetAmbitionBias(CharacterAmbition ambition)
+        {
+            return ambition switch
             {
-                var inSet = chosen.Where(i => set.Contains(i.Type)).ToList();
-                if (inSet.Count <= 1) continue;
-                var best = inSet.OrderByDescending(scoreOf).First();
-                chosen = chosen.Except(inSet).ToList();
-                chosen.Add(best);
-            }
-            return chosen;
+                CharacterAmbition.GainPower => (0.8, 0.7, 1.2, 1.1, 1.2, 1.3, 1.0, 1.0, 1.3, 1.0, 0.9, 0.8, 0.9, 0.8),
+                CharacterAmbition.BuildWealth => (0.9, 0.8, 1.1, 1.3, 1.1, 0.8, 1.2, 0.7, 0.8, 0.7, 0.6, 1.0, 1.2, 1.3),
+                CharacterAmbition.EnsureFamilyLegacy => (1.2, 1.3, 0.8, 0.9, 0.9, 0.7, 0.9, 0.8, 0.7, 0.6, 0.5, 1.1, 0.7, 0.6),
+                CharacterAmbition.SeekAdventure => (0.9, 0.8, 1.2, 0.9, 0.9, 1.0, 0.9, 1.0, 1.0, 0.8, 0.7, 1.3, 1.2, 1.2),
+                _ => (1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0)
+            };
         }
 
         private List<ScoredIntent> ResolveConflictsTargetAware(Character actor, List<ScoredIntent> candidates, int take, Func<Guid, Guid> fac)
@@ -953,35 +280,5 @@ namespace SkyHorizont.Infrastructure.Social
 
             return kept;
         }
-    }
-
-    public sealed class PlannerConfig
-    {
-        public int MaxIntentsPerMonth { get; init; } = 2;
-        public double ScoreNoiseMax { get; init; } = 5.0;
-        public double RomanceWeight { get; init; } = 0.9;
-        public double FamilyWeight { get; init; } = 0.7;
-        public double LoverVisitWeight { get; init; } = 1.0;
-        public double SpyWeight { get; init; } = 1.0;
-        public double BribeWeight { get; init; } = 0.8;
-        public double RecruitWeight { get; init; } = 0.9;
-        public double DefectionWeight { get; init; } = 1.0;
-        public double NegotiateWeight { get; init; } = 0.7;
-        public double QuarrelWeight { get; init; } = 0.6;
-        public double AssassinateWeight { get; init; } = 0.65;
-        public double TortureWeight { get; init; } = 0.75;
-        public double RapeWeight { get; init; } = 0.6;
-        public double TravelWeight { get; init; } = 0.8;
-        public double BecomePirateWeight { get; init; } = 0.9;
-        public double RaidConvoyWeight { get; init; } = 1.0;
-        public int MinBribeBudget { get; init; } = 200;
-        public double AssassinateFrequency { get; init; } = 0.05;
-        public int MaxCandidatePool { get; init; } = 60;
-        public int MaxCrossFactionPool { get; init; } = 40;
-        public int QuarrelOpinionThreshold { get; init; } = -25;
-        public int AssassinationOpinionThreshold { get; init; } = -50;
-        public int ConflictBuffer { get; init; } = 8;
-
-        public static PlannerConfig Default => new();
     }
 }

--- a/Infrastructure/Social/IntentRules/AssassinateIntentRule.cs
+++ b/Infrastructure/Social/IntentRules/AssassinateIntentRule.cs
@@ -1,0 +1,64 @@
+using SkyHorizont.Domain.Entity;
+using SkyHorizont.Domain.Factions;
+using SkyHorizont.Domain.Social;
+using SkyHorizont.Domain.Services;
+
+namespace SkyHorizont.Infrastructure.Social.IntentRules
+{
+    public sealed class AssassinateIntentRule : IIntentRule
+    {
+        private readonly IFactionService _factions;
+        private readonly IRandomService _rng;
+
+        public AssassinateIntentRule(IFactionService factions, IRandomService rng)
+        {
+            _factions = factions;
+            _rng = rng;
+        }
+
+        public IEnumerable<ScoredIntent> Generate(IntentContext ctx)
+        {
+            var target = PickAssassinationTarget(ctx.OtherFactionCharacters, ctx.OpinionOf, ctx.Config);
+            if (target == null)
+                yield break;
+
+            var score = ScoreAssassinate(ctx.Actor, target, ctx.ActorFactionId, ctx.FactionStatus, ctx.FactionOf, ctx.OpinionOf, ctx.Config) * ctx.AmbitionBias.Assassinate;
+            if (score > 0)
+                yield return new ScoredIntent(IntentType.Assassinate, score, target.Id, null, null);
+        }
+
+        private Character? PickAssassinationTarget(IReadOnlyList<Character> otherFaction, Func<Guid, int> opin, PlannerConfig cfg)
+        {
+            if (_rng.NextDouble() > cfg.AssassinateFrequency) return null;
+            var pool = otherFaction
+                .Select(c => new { C = c, O = opin(c.Id) })
+                .Where(x => x.O < cfg.AssassinationOpinionThreshold && x.C.Rank >= Rank.Major)
+                .OrderBy(x => x.O)
+                .ToList();
+            if (pool.Count == 0) return null;
+            return pool.First().C;
+        }
+
+        private double ScoreAssassinate(Character actor, Character target, Guid actorFactionId, FactionStatus factionStatus, Func<Guid, Guid> fac, Func<Guid, int> opin, PlannerConfig cfg)
+        {
+            var opinion = opin(target.Id);
+            var baseScore = 0.0;
+            baseScore += actor.Skills.Military * 0.4;
+            baseScore += Math.Max(0, -opinion) * 0.2;
+            var traits = PersonalityTraits.GetActiveTraits(actor.Personality);
+            foreach (var (traitName, intensity) in traits["Neuroticism"].Concat(traits["Extraversion"]))
+                baseScore += PersonalityTraits.GetTraitEffect(traitName, actor.Personality);
+            baseScore += PersonalityTraits.GetTraitCombinationEffect("ImpulsiveAnger", actor.Personality);
+            baseScore -= (actor.Personality.Conscientiousness - 50) * 0.2;
+            baseScore -= (actor.Personality.Agreeableness - 50) * 0.2;
+            var targetFaction = fac(target.Id);
+            if (_factions.IsAtWar(actorFactionId, targetFaction)) baseScore += 20;
+            if (factionStatus.HasUnrest) baseScore += 10;
+            if (actor.Rank <= Rank.Captain && actor.Skills.Military < 70) baseScore -= 20;
+            baseScore -= 15;
+            return Clamp0to100(baseScore * cfg.AssassinateWeight);
+        }
+
+        private static double Clamp0to100(double v) => v < 0 ? 0 : (v > 100 ? 100 : v);
+    }
+}

--- a/Infrastructure/Social/IntentRules/BecomePirateIntentRule.cs
+++ b/Infrastructure/Social/IntentRules/BecomePirateIntentRule.cs
@@ -1,0 +1,61 @@
+using SkyHorizont.Domain.Entity;
+using SkyHorizont.Domain.Galaxy.Planet;
+using SkyHorizont.Domain.Factions;
+using SkyHorizont.Domain.Travel;
+using SkyHorizont.Domain.Social;
+using SkyHorizont.Domain.Services;
+
+namespace SkyHorizont.Infrastructure.Social.IntentRules
+{
+    public sealed class BecomePirateIntentRule : IIntentRule
+    {
+        private readonly IPlanetRepository _planets;
+        private readonly IPiracyService _piracy;
+
+        public BecomePirateIntentRule(IPlanetRepository planets, IPiracyService piracy)
+        {
+            _planets = planets;
+            _piracy = piracy;
+        }
+
+        public IEnumerable<ScoredIntent> Generate(IntentContext ctx)
+        {
+            if (_piracy.IsPirateFaction(ctx.ActorFactionId))
+                yield break;
+
+            var score = ScoreBecomePirate(ctx.Actor, ctx.ActorFactionId, ctx.ActorLeaderId, ctx.SystemSecurity, ctx.OpinionOf, ctx.FactionStatus, ctx.Config) * ctx.AmbitionBias.BecomePirate;
+            if (score > 0)
+                yield return new ScoredIntent(IntentType.BecomePirate, score, null, null, null);
+        }
+
+        private double ScoreBecomePirate(Character actor, Guid actorFactionId, Guid? actorLeaderId, SystemSecurity? systemSecurity, Func<Guid, int> opin, FactionStatus factionStatus, PlannerConfig cfg)
+        {
+            var planets = _planets.GetPlanetsControlledByFaction(actorFactionId);
+            var isGovernor = planets.Any(p => p.GovernorId == actor.Id);
+            if (isGovernor || actor.Rank >= Rank.General || actor.Balance > 2000)
+                return 0;
+
+            double baseScore = 0.0;
+            if (actorLeaderId.HasValue)
+                baseScore += Clamp0to100Map(Math.Max(0, -opin(actorLeaderId.Value)));
+            baseScore += (50 - actor.Personality.Conscientiousness) * 0.3;
+            baseScore += (50 - actor.Personality.Agreeableness) * 0.3;
+            baseScore += PersonalityTraits.GetTraitEffect("ThrillSeeker", actor.Personality);
+            if (actor.Balance < 500)
+                baseScore += 20;
+            else if (actor.Balance < 1000)
+                baseScore += 10;
+            if (systemSecurity != null)
+            {
+                baseScore += systemSecurity.PirateActivity * 0.2;
+                baseScore -= systemSecurity.PatrolStrength * 0.1;
+            }
+            if (factionStatus.HasUnrest)
+                baseScore += 15;
+            return Clamp0to100(baseScore * cfg.BecomePirateWeight);
+        }
+
+        private static double Clamp0to100Map(double v) => Math.Clamp(v, 0, 100);
+        private static double Clamp0to100(double v) => v < 0 ? 0 : (v > 100 ? 100 : v);
+    }
+}

--- a/Infrastructure/Social/IntentRules/BribeIntentRule.cs
+++ b/Infrastructure/Social/IntentRules/BribeIntentRule.cs
@@ -1,0 +1,61 @@
+using SkyHorizont.Domain.Entity;
+using SkyHorizont.Domain.Factions;
+using SkyHorizont.Domain.Social;
+using SkyHorizont.Domain.Services;
+
+namespace SkyHorizont.Infrastructure.Social.IntentRules
+{
+    public sealed class BribeIntentRule : IIntentRule
+    {
+        private readonly IFactionService _factions;
+        private readonly IRandomService _rng;
+
+        public BribeIntentRule(IFactionService factions, IRandomService rng)
+        {
+            _factions = factions;
+            _rng = rng;
+        }
+
+        public IEnumerable<ScoredIntent> Generate(IntentContext ctx)
+        {
+            var target = PickBribeTarget(ctx.OtherFactionCharacters, ctx.OpinionOf);
+            if (target == null)
+                yield break;
+
+            var score = ScoreBribe(ctx.Actor, target, ctx.ActorFactionId, ctx.FactionStatus, ctx.FactionOf, ctx.Config) * ctx.AmbitionBias.Bribe;
+            if (score > 0)
+                yield return new ScoredIntent(IntentType.Bribe, score, target.Id, null, null);
+        }
+
+        private Character? PickBribeTarget(IReadOnlyList<Character> candidates, Func<Guid, int> opin)
+        {
+            var pool = candidates
+                .Where(c => opin(c.Id) > -50)
+                .ToList();
+            if (pool.Count == 0) return null;
+            return pool.Select(c => new
+            {
+                C = c,
+                Score = (100 - c.Personality.Conscientiousness) + (100 - c.Personality.Agreeableness) + _rng.NextInt(0, 20)
+            })
+            .OrderByDescending(x => x.Score)
+            .First().C;
+        }
+
+        private double ScoreBribe(Character actor, Character target, Guid actorFactionId, FactionStatus factionStatus, Func<Guid, Guid> fac, PlannerConfig cfg)
+        {
+            var baseScore = 20.0;
+            var hardness = (target.Personality.Conscientiousness + target.Personality.Agreeableness) / 2.0;
+            baseScore += (100 - hardness) * 0.4;
+            baseScore -= (actor.Personality.Conscientiousness - 50) * 0.2;
+            baseScore -= (actor.Personality.Agreeableness - 50) * 0.2;
+            var targetFaction = fac(target.Id);
+            if (_factions.IsAtWar(actorFactionId, targetFaction)) baseScore += 10;
+            if (factionStatus.EconomyWeak) baseScore += 10;
+            if (actor.Balance < cfg.MinBribeBudget) baseScore -= 25;
+            return Clamp0to100(baseScore * cfg.BribeWeight);
+        }
+
+        private static double Clamp0to100(double v) => v < 0 ? 0 : (v > 100 ? 100 : v);
+    }
+}

--- a/Infrastructure/Social/IntentRules/CourtshipIntentRule.cs
+++ b/Infrastructure/Social/IntentRules/CourtshipIntentRule.cs
@@ -1,0 +1,69 @@
+using SkyHorizont.Domain.Entity;
+using SkyHorizont.Domain.Factions;
+using SkyHorizont.Domain.Services;
+using SkyHorizont.Domain.Social;
+
+namespace SkyHorizont.Infrastructure.Social.IntentRules
+{
+    public sealed class CourtshipIntentRule : IIntentRule
+    {
+        private readonly IRandomService _rng;
+
+        public CourtshipIntentRule(IRandomService rng)
+        {
+            _rng = rng;
+        }
+
+        public IEnumerable<ScoredIntent> Generate(IntentContext ctx)
+        {
+            var candidates = ctx.SameFactionCharacters.Concat(ctx.OtherFactionCharacters).Distinct().ToList();
+            var target = PickRomanticTarget(ctx.Actor, candidates, ctx.FactionOf, ctx.OpinionOf);
+            if (target == null)
+                yield break;
+
+            var score = ScoreCourtship(ctx.Actor, target, ctx.FactionStatus, ctx.OpinionOf, ctx.Config) * ctx.AmbitionBias.Court;
+            if (score > 0)
+                yield return new ScoredIntent(IntentType.Court, score, target.Id, null, null);
+        }
+
+        private Character? PickRomanticTarget(Character actor, List<Character> candidates, Func<Guid, Guid> fac, Func<Guid, int> opin)
+        {
+            var lovers = actor.Relationships.Where(r => r.Type == RelationshipType.Lover || r.Type == RelationshipType.Spouse)
+                                            .Select(r => r.TargetCharacterId)
+                                            .ToHashSet();
+            var known = candidates.Where(c => lovers.Contains(c.Id)).ToList();
+            if (known.Count > 0) return known[_rng.NextInt(0, known.Count)];
+            var myFaction = fac(actor.Id);
+            var pool = candidates.Where(c => fac(c.Id) == myFaction).ToList();
+            if (pool.Count == 0) return null;
+            return pool.Select(c => new
+            {
+                C = c,
+                Score = 0.6 * opin(c.Id) + 0.4 * actor.Personality.CheckCompatibility(c.Personality)
+            })
+            .OrderByDescending(x => x.Score)
+            .FirstOrDefault()?.C;
+        }
+
+        private double ScoreCourtship(Character actor, Character target, FactionStatus factionStatus, Func<Guid, int> opin, PlannerConfig cfg)
+        {
+            var opinion = opin(target.Id);
+            var baseScore = 0.0;
+
+            baseScore += Math.Clamp(actor.Personality.CheckCompatibility(target.Personality), 0, 100);
+            baseScore += Math.Clamp(Math.Max(0, opinion + 50), 0, 100);
+
+            var traits = PersonalityTraits.GetActiveTraits(actor.Personality);
+            foreach (var (traitName, _) in traits["Extraversion"].Concat(traits["Agreeableness"]))
+                baseScore += PersonalityTraits.GetTraitEffect(traitName, actor.Personality);
+
+            if (actor.Relationships.Any(r => r.Type == RelationshipType.Lover || r.Type == RelationshipType.Spouse))
+                baseScore += 15;
+
+            if (actor.Personality.Extraversion < 40) baseScore -= 10;
+            if (factionStatus.HasAlliance) baseScore += 10;
+
+            return Math.Clamp(baseScore * cfg.RomanceWeight, 0, 100);
+        }
+    }
+}

--- a/Infrastructure/Social/IntentRules/DefectIntentRule.cs
+++ b/Infrastructure/Social/IntentRules/DefectIntentRule.cs
@@ -1,0 +1,59 @@
+using SkyHorizont.Domain.Entity;
+using SkyHorizont.Domain.Factions;
+using SkyHorizont.Domain.Social;
+using SkyHorizont.Domain.Services;
+
+namespace SkyHorizont.Infrastructure.Social.IntentRules
+{
+    public sealed class DefectIntentRule : IIntentRule
+    {
+        private readonly IFactionService _factions;
+        private readonly IRandomService _rng;
+
+        public DefectIntentRule(IFactionService factions, IRandomService rng)
+        {
+            _factions = factions;
+            _rng = rng;
+        }
+
+        public IEnumerable<ScoredIntent> Generate(IntentContext ctx)
+        {
+            if (!ctx.ActorLeaderId.HasValue)
+                yield break;
+
+            var targetFaction = PickDefectionFaction(ctx.ActorFactionId);
+            if (targetFaction == Guid.Empty)
+                yield break;
+
+            var score = ScoreDefect(ctx.Actor, ctx.ActorLeaderId.Value, ctx.ActorFactionId, targetFaction, ctx.FactionStatus, ctx.OpinionOf, ctx.Config) * ctx.AmbitionBias.Defect;
+            if (score > 0)
+                yield return new ScoredIntent(IntentType.Defect, score, null, targetFaction, null);
+        }
+
+        private Guid PickDefectionFaction(Guid actorFactionId)
+        {
+            var rivals = _factions.GetAllRivalFactions(actorFactionId).ToList();
+            if (rivals.Count == 0) return Guid.Empty;
+            var war = rivals.Where(f => _factions.IsAtWar(actorFactionId, f)).ToList();
+            if (war.Count > 0) return war[_rng.NextInt(0, war.Count)];
+            return rivals[_rng.NextInt(0, rivals.Count)];
+        }
+
+        private double ScoreDefect(Character actor, Guid leaderId, Guid actorFactionId, Guid targetFactionId, FactionStatus factionStatus, Func<Guid, int> opin, PlannerConfig cfg)
+        {
+            var opinionLeader = opin(leaderId);
+            var baseScore = Clamp0to100Map(-opinionLeader) * 0.8;
+            baseScore += (50 - actor.Personality.Conscientiousness) * 0.2;
+            baseScore += (50 - actor.Personality.Agreeableness) * 0.2;
+            baseScore += (actor.Personality.Openness - 50) * 0.15;
+            baseScore -= (actor.Personality.Neuroticism - 50) * 0.15;
+            if (_factions.IsAtWar(actorFactionId, targetFactionId)) baseScore += 10;
+            if (factionStatus.HasUnrest) baseScore += 15;
+            baseScore -= (int)actor.Rank * 2;
+            return Clamp0to100(baseScore * cfg.DefectionWeight);
+        }
+
+        private static double Clamp0to100Map(double v) => Math.Clamp(v, 0, 100);
+        private static double Clamp0to100(double v) => v < 0 ? 0 : (v > 100 ? 100 : v);
+    }
+}

--- a/Infrastructure/Social/IntentRules/NegotiateIntentRule.cs
+++ b/Infrastructure/Social/IntentRules/NegotiateIntentRule.cs
@@ -1,0 +1,58 @@
+using SkyHorizont.Domain.Entity;
+using SkyHorizont.Domain.Factions;
+using SkyHorizont.Domain.Social;
+using SkyHorizont.Domain.Services;
+
+namespace SkyHorizont.Infrastructure.Social.IntentRules
+{
+    public sealed class NegotiateIntentRule : IIntentRule
+    {
+        private readonly IFactionService _factions;
+        private readonly IRandomService _rng;
+
+        public NegotiateIntentRule(IFactionService factions, IRandomService rng)
+        {
+            _factions = factions;
+            _rng = rng;
+        }
+
+        public IEnumerable<ScoredIntent> Generate(IntentContext ctx)
+        {
+            var targetFaction = PickNegotiateFaction(ctx.Actor, ctx.ActorFactionId);
+            if (targetFaction == Guid.Empty)
+                yield break;
+
+            var score = ScoreNegotiate(ctx.Actor, ctx.ActorFactionId, targetFaction, ctx.FactionStatus, ctx.Config) * ctx.AmbitionBias.Negotiate;
+            if (score > 0)
+                yield return new ScoredIntent(IntentType.Negotiate, score, null, targetFaction, null);
+        }
+
+        private Guid PickNegotiateFaction(Character actor, Guid actorFactionId)
+        {
+            var rivals = _factions.GetAllRivalFactions(actorFactionId).ToList();
+            if (rivals.Count == 0) return Guid.Empty;
+            if (PersonalityTraits.Cheerful(actor.Personality) || PersonalityTraits.Trusting(actor.Personality))
+            {
+                var war = rivals.Where(f => _factions.IsAtWar(actorFactionId, f)).ToList();
+                if (war.Count > 0) return war[_rng.NextInt(0, war.Count)];
+            }
+            return rivals[_rng.NextInt(0, rivals.Count)];
+        }
+
+        private double ScoreNegotiate(Character actor, Guid myFactionId, Guid targetFactionId, FactionStatus factionStatus, PlannerConfig cfg)
+        {
+            var baseScore = 25.0;
+            baseScore += (actor.Personality.Agreeableness - 50) * 0.3;
+            baseScore += (actor.Personality.Extraversion - 50) * 0.2;
+            var traits = PersonalityTraits.GetActiveTraits(actor.Personality);
+            foreach (var (traitName, intensity) in traits["Agreeableness"].Concat(traits["Extraversion"]))
+                baseScore += PersonalityTraits.GetTraitEffect(traitName, actor.Personality);
+            if (_factions.IsAtWar(myFactionId, targetFactionId)) baseScore += 10;
+            if (factionStatus.EconomyWeak) baseScore += 10;
+            baseScore += (int)actor.Rank * 3;
+            return Clamp0to100(baseScore * cfg.NegotiateWeight);
+        }
+
+        private static double Clamp0to100(double v) => v < 0 ? 0 : (v > 100 ? 100 : v);
+    }
+}

--- a/Infrastructure/Social/IntentRules/QuarrelIntentRule.cs
+++ b/Infrastructure/Social/IntentRules/QuarrelIntentRule.cs
@@ -1,0 +1,56 @@
+using SkyHorizont.Domain.Entity;
+using SkyHorizont.Domain.Factions;
+using SkyHorizont.Domain.Social;
+using SkyHorizont.Domain.Services;
+
+namespace SkyHorizont.Infrastructure.Social.IntentRules
+{
+    public sealed class QuarrelIntentRule : IIntentRule
+    {
+        private readonly IRandomService _rng;
+
+        public QuarrelIntentRule(IRandomService rng)
+        {
+            _rng = rng;
+        }
+
+        public IEnumerable<ScoredIntent> Generate(IntentContext ctx)
+        {
+            var target = PickQuarrelTarget(ctx.Actor, ctx.OtherFactionCharacters, ctx.OpinionOf, ctx.Config);
+            if (target == null)
+                yield break;
+
+            var score = ScoreQuarrel(ctx.Actor, target, ctx.FactionStatus, ctx.OpinionOf, ctx.Config) * ctx.AmbitionBias.Quarrel;
+            if (score > 0)
+                yield return new ScoredIntent(IntentType.Quarrel, score, target.Id, null, null);
+        }
+
+        private Character? PickQuarrelTarget(Character actor, IReadOnlyList<Character> candidates, Func<Guid, int> opin, PlannerConfig cfg)
+        {
+            var negatives = candidates
+                .Select(c => new { C = c, O = opin(c.Id) })
+                .Where(x => x.O < cfg.QuarrelOpinionThreshold)
+                .OrderBy(x => x.O)
+                .ToList();
+            if (negatives.Count == 0) return null;
+            return negatives[_rng.NextInt(0, Math.Min(3, negatives.Count))].C;
+        }
+
+        private double ScoreQuarrel(Character actor, Character target, FactionStatus factionStatus, Func<Guid, int> opin, PlannerConfig cfg)
+        {
+            var opinion = opin(target.Id);
+            var baseScore = 0.0;
+            if (opinion < cfg.QuarrelOpinionThreshold)
+                baseScore += Clamp0to100Map(cfg.QuarrelOpinionThreshold - opinion);
+            var traits = PersonalityTraits.GetActiveTraits(actor.Personality);
+            foreach (var (traitName, intensity) in traits["Neuroticism"])
+                baseScore += PersonalityTraits.GetTraitEffect(traitName, actor.Personality);
+            if ((int)target.Rank > (int)actor.Rank) baseScore -= 10;
+            if (factionStatus.HasUnrest) baseScore += 10;
+            return Clamp0to100(baseScore * cfg.QuarrelWeight);
+        }
+
+        private static double Clamp0to100Map(double v) => Math.Clamp(v, 0, 100);
+        private static double Clamp0to100(double v) => v < 0 ? 0 : (v > 100 ? 100 : v);
+    }
+}

--- a/Infrastructure/Social/IntentRules/RaidConvoyIntentRule.cs
+++ b/Infrastructure/Social/IntentRules/RaidConvoyIntentRule.cs
@@ -1,0 +1,84 @@
+using SkyHorizont.Domain.Entity;
+using SkyHorizont.Domain.Factions;
+using SkyHorizont.Domain.Galaxy.Planet;
+using SkyHorizont.Domain.Social;
+using SkyHorizont.Domain.Services;
+using SkyHorizont.Domain.Travel;
+
+namespace SkyHorizont.Infrastructure.Social.IntentRules
+{
+    public sealed class RaidConvoyIntentRule : IIntentRule
+    {
+        private readonly IPlanetRepository _planets;
+        private readonly IFactionService _factions;
+        private readonly IPiracyService _piracy;
+        private readonly IRandomService _rng;
+
+        public RaidConvoyIntentRule(IPlanetRepository planets, IFactionService factions, IPiracyService piracy, IRandomService rng)
+        {
+            _planets = planets;
+            _factions = factions;
+            _piracy = piracy;
+            _rng = rng;
+        }
+
+        public IEnumerable<ScoredIntent> Generate(IntentContext ctx)
+        {
+            if (!_piracy.IsPirateFaction(ctx.ActorFactionId))
+                yield break;
+
+            var targetSystem = PickRaidTargetSystem(ctx.ActorSystemId, ctx.ActorFactionId);
+            if (!targetSystem.HasValue)
+                yield break;
+
+            var security = GetSystemSecurity(targetSystem.Value);
+            var score = ScoreRaidConvoy(ctx.Actor, targetSystem.Value, security, ctx.Config) * ctx.AmbitionBias.RaidConvoy;
+            if (score > 0)
+                yield return new ScoredIntent(IntentType.RaidConvoy, score, null, targetSystem.Value, null);
+        }
+
+        private Guid? PickRaidTargetSystem(Guid? actorSystemId, Guid actorFactionId)
+        {
+            if (!actorSystemId.HasValue) return null;
+            var systems = _planets.GetAll()
+                .GroupBy(p => p.SystemId)
+                .Select(g => new
+                {
+                    SystemId = g.Key,
+                    Traffic = _piracy.GetTrafficLevel(g.Key),
+                    PirateActivity = _piracy.GetPirateActivity(g.Key),
+                    PatrolStrength = GetSystemSecurity(g.Key).PatrolStrength
+                })
+                .Where(s => s.SystemId != actorSystemId.Value && !_piracy.IsPirateFaction(_factions.GetFactionIdForSystem(s.SystemId)))
+                .OrderByDescending(s => s.Traffic * 0.5 + s.PirateActivity * 0.3 - s.PatrolStrength * 0.2)
+                .Take(3)
+                .ToList();
+            return systems.Count > 0 ? systems[_rng.NextInt(0, systems.Count)].SystemId : null;
+        }
+
+        private double ScoreRaidConvoy(Character actor, Guid systemId, SystemSecurity security, PlannerConfig cfg)
+        {
+            var baseScore = 0.0;
+            baseScore += (actor.Skills.Military - 50) * 0.4;
+            baseScore += (50 - actor.Personality.Agreeableness) * 0.2;
+            var traits = PersonalityTraits.GetActiveTraits(actor.Personality);
+            foreach (var (traitName, intensity) in traits["Extraversion"].Concat(traits["Neuroticism"]))
+                baseScore += PersonalityTraits.GetTraitEffect(traitName, actor.Personality);
+            baseScore += PersonalityTraits.GetTraitCombinationEffect("ImpulsiveAnger", actor.Personality);
+            baseScore += security.PirateActivity * 0.4;
+            baseScore += security.Traffic * 0.3;
+            baseScore -= security.PatrolStrength * 0.2;
+            return Clamp0to100(baseScore * cfg.RaidConvoyWeight);
+        }
+
+        private SystemSecurity GetSystemSecurity(Guid systemId)
+        {
+            var securityLevel = _piracy.GetPirateActivity(systemId);
+            var traffic = _piracy.GetTrafficLevel(systemId);
+            var patrolStrength = _planets.GetAll().Where(p => p.SystemId == systemId).Sum(p => p.BaseDefense);
+            return new SystemSecurity(systemId, (int)patrolStrength, securityLevel, traffic);
+        }
+
+        private static double Clamp0to100(double v) => v < 0 ? 0 : (v > 100 ? 100 : v);
+    }
+}

--- a/Infrastructure/Social/IntentRules/RapePrisonerIntentRule.cs
+++ b/Infrastructure/Social/IntentRules/RapePrisonerIntentRule.cs
@@ -1,0 +1,65 @@
+using SkyHorizont.Domain.Entity;
+using SkyHorizont.Domain.Factions;
+using SkyHorizont.Domain.Social;
+using SkyHorizont.Domain.Services;
+
+namespace SkyHorizont.Infrastructure.Social.IntentRules
+{
+    public sealed class RapePrisonerIntentRule : IIntentRule
+    {
+        private readonly IFactionService _factions;
+        private readonly IRandomService _rng;
+
+        public RapePrisonerIntentRule(IFactionService factions, IRandomService rng)
+        {
+            _factions = factions;
+            _rng = rng;
+        }
+
+        public IEnumerable<ScoredIntent> Generate(IntentContext ctx)
+        {
+            var target = PickRapeTarget(ctx.Captives, ctx.OpinionOf);
+            if (target == null)
+                yield break;
+
+            var score = ScoreRape(ctx.Actor, target, ctx.ActorFactionId, ctx.FactionStatus, ctx.FactionOf, ctx.OpinionOf, ctx.Config) * ctx.AmbitionBias.Rape;
+            if (score > 0)
+                yield return new ScoredIntent(IntentType.RapePrisoner, score, target.Id, null, null);
+        }
+
+        private Character? PickRapeTarget(IReadOnlyList<Character> captives, Func<Guid, int> opin)
+        {
+            if (captives.Count == 0)
+                return null;
+            var pool = captives
+                .Select(c => new { C = c, Score = -opin(c.Id) + _rng.NextInt(0, 30) })
+                .Where(x => x.Score > 0)
+                .OrderByDescending(x => x.Score)
+                .ToList();
+            return pool.Count == 0 ? null : pool.First().C;
+        }
+
+        private double ScoreRape(Character actor, Character target, Guid actorFactionId, FactionStatus factionStatus, Func<Guid, Guid> fac, Func<Guid, int> opin, PlannerConfig cfg)
+        {
+            var opinion = opin(target.Id);
+            var baseScore = 0.0;
+            baseScore += (50 - actor.Personality.Agreeableness) * 0.5;
+            baseScore += (50 - actor.Personality.Conscientiousness) * 0.3;
+            if (opinion < 0) baseScore += Clamp0to100Map(-opinion) * 0.6;
+            var traits = PersonalityTraits.GetActiveTraits(actor.Personality);
+            foreach (var (traitName, intensity) in traits["Neuroticism"].Concat(traits["Extraversion"]))
+                baseScore += PersonalityTraits.GetTraitEffect(traitName, actor.Personality);
+            baseScore += PersonalityTraits.GetTraitCombinationEffect("ImpulsiveAnger", actor.Personality);
+            var targetFaction = fac(target.Id);
+            if (_factions.IsAtWar(actorFactionId, targetFaction)) baseScore += 15;
+            if (factionStatus.HasUnrest) baseScore += 5;
+            baseScore += (int)actor.Rank * 2;
+            baseScore -= (actor.Personality.Neuroticism - 50) * 0.2;
+            if (actor.Rank < Rank.Captain) baseScore -= 25;
+            return Clamp0to100(baseScore * cfg.RapeWeight);
+        }
+
+        private static double Clamp0to100Map(double v) => Math.Clamp(v, 0, 100);
+        private static double Clamp0to100(double v) => v < 0 ? 0 : (v > 100 ? 100 : v);
+    }
+}

--- a/Infrastructure/Social/IntentRules/RecruitIntentRule.cs
+++ b/Infrastructure/Social/IntentRules/RecruitIntentRule.cs
@@ -1,0 +1,91 @@
+using SkyHorizont.Domain.Entity;
+using SkyHorizont.Domain.Factions;
+using SkyHorizont.Domain.Galaxy.Planet;
+using SkyHorizont.Domain.Social;
+using SkyHorizont.Domain.Services;
+using SkyHorizont.Domain.Travel;
+
+namespace SkyHorizont.Infrastructure.Social.IntentRules
+{
+    public sealed class RecruitIntentRule : IIntentRule
+    {
+        private readonly IFactionService _factions;
+        private readonly IRandomService _rng;
+        private readonly IPiracyService _piracy;
+        private readonly IPlanetRepository _planets;
+
+        public RecruitIntentRule(IFactionService factions, IRandomService rng, IPiracyService piracy, IPlanetRepository planets)
+        {
+            _factions = factions;
+            _rng = rng;
+            _piracy = piracy;
+            _planets = planets;
+        }
+
+        public IEnumerable<ScoredIntent> Generate(IntentContext ctx)
+        {
+            if (!IsRecruiter(ctx.Actor))
+                yield break;
+
+            var target = PickRecruitTarget(ctx.ActorFactionId, ctx.OtherFactionCharacters, ctx.FactionOf);
+            if (target == null)
+                yield break;
+
+            var score = ScoreRecruit(ctx.Actor, target, ctx.ActorFactionId, ctx.FactionStatus, ctx.FactionOf, ctx.OpinionOf, ctx.Config) * ctx.AmbitionBias.Recruit;
+            if (score > 0)
+                yield return new ScoredIntent(IntentType.Recruit, score, target.Id, null, null);
+        }
+
+        private bool IsRecruiter(Character actor) => actor.Rank >= Rank.Captain || actor.Skills.Military >= 70;
+
+        private Character? PickRecruitTarget(Guid actorFactionId, IReadOnlyList<Character> candidates, Func<Guid, Guid> fac)
+        {
+            var pool = candidates.Where(c => fac(c.Id) != actorFactionId).ToList();
+            if (pool.Count == 0) return null;
+            return pool.Select(c => new
+            {
+                C = c,
+                Talent = (c.Skills.Military + c.Skills.Intelligence + c.Skills.Economy + c.Skills.Research) / 4.0
+            })
+            .OrderByDescending(x => x.Talent + _rng.NextInt(0, 10))
+            .First().C;
+        }
+
+        private double ScoreRecruit(Character actor, Character target, Guid actorFactionId, FactionStatus factionStatus, Func<Guid, Guid> fac, Func<Guid, int> opin, PlannerConfig cfg)
+        {
+            var baseScore = 30.0;
+            var talent = (target.Skills.Military + target.Skills.Intelligence + target.Skills.Economy + target.Skills.Research) / 4.0;
+            baseScore += talent * 0.4;
+            baseScore += (int)actor.Rank * 3;
+            baseScore += (actor.Personality.Agreeableness - 50) * 0.2;
+            baseScore += (actor.Personality.Extraversion - 50) * 0.2;
+
+            var targetFactionId = fac(target.Id);
+            var sameFaction = actorFactionId == targetFactionId;
+            if (sameFaction)
+                baseScore -= 10;
+            if (factionStatus.HasUnrest)
+                baseScore += 10;
+
+            try
+            {
+                int opinion = opin(target.Id);
+                baseScore += Math.Clamp(opinion, -50, 50) * 0.10;
+            }
+            catch { }
+
+            if (_piracy.IsPirateFaction(actorFactionId))
+            {
+                if (target.Rank >= Rank.General)
+                    baseScore -= 10;
+                var isGovernor = _planets.GetAll().Any(p => p.GovernorId == target.Id);
+                if (isGovernor)
+                    baseScore -= 15;
+            }
+
+            return Clamp0to100(baseScore * cfg.RecruitWeight);
+        }
+
+        private static double Clamp0to100(double v) => v < 0 ? 0 : (v > 100 ? 100 : v);
+    }
+}

--- a/Infrastructure/Social/IntentRules/SpyIntentRule.cs
+++ b/Infrastructure/Social/IntentRules/SpyIntentRule.cs
@@ -1,0 +1,67 @@
+using SkyHorizont.Domain.Entity;
+using SkyHorizont.Domain.Factions;
+using SkyHorizont.Domain.Social;
+using SkyHorizont.Domain.Services;
+
+namespace SkyHorizont.Infrastructure.Social.IntentRules
+{
+    public sealed class SpyIntentRule : IIntentRule
+    {
+        private readonly IFactionService _factions;
+        private readonly IRandomService _rng;
+
+        public SpyIntentRule(IFactionService factions, IRandomService rng)
+        {
+            _factions = factions;
+            _rng = rng;
+        }
+
+        public IEnumerable<ScoredIntent> Generate(IntentContext ctx)
+        {
+            var scoreBase = ScoreSpy(ctx.Actor, ctx.FactionStatus, ctx.Config) * ctx.AmbitionBias.Spy;
+            if (scoreBase <= 0)
+                yield break;
+
+            var faction = PickSpyFaction(ctx.ActorFactionId);
+            if (faction != Guid.Empty)
+                yield return new ScoredIntent(IntentType.Spy, scoreBase, null, faction, null);
+
+            var character = PickSpyCharacter(ctx.ActorFactionId, ctx.OtherFactionCharacters, ctx.FactionOf, ctx.OpinionOf);
+            if (character != null)
+                yield return new ScoredIntent(IntentType.Spy, scoreBase, character.Id, null, null);
+        }
+
+        private Guid PickSpyFaction(Guid actorFactionId)
+        {
+            var rivals = _factions.GetAllRivalFactions(actorFactionId).ToList();
+            if (rivals.Count == 0) return Guid.Empty;
+            var war = rivals.Where(f => _factions.IsAtWar(actorFactionId, f)).ToList();
+            if (war.Count > 0) return war[_rng.NextInt(0, war.Count)];
+            return rivals[_rng.NextInt(0, rivals.Count)];
+        }
+
+        private Character? PickSpyCharacter(Guid actorFactionId, IReadOnlyList<Character> candidates, Func<Guid, Guid> fac, Func<Guid, int> opin)
+        {
+            var pool = candidates
+                .Where(c => fac(c.Id) != actorFactionId)
+                .Select(c => new { C = c, Score = (int)c.Rank * 10 - opin(c.Id) + _rng.NextInt(0, 10) })
+                .OrderByDescending(x => x.Score)
+                .ToList();
+            return pool.Count == 0 ? null : pool.First().C;
+        }
+
+        private double ScoreSpy(Character actor, FactionStatus factionStatus, PlannerConfig cfg)
+        {
+            var baseScore = actor.Skills.Intelligence * 0.6;
+            var traits = PersonalityTraits.GetActiveTraits(actor.Personality);
+            foreach (var (traitName, intensity) in traits["Openness"].Concat(traits["Neuroticism"]))
+                baseScore += PersonalityTraits.GetTraitEffect(traitName, actor.Personality);
+            baseScore += (int)actor.Rank * 2;
+            if (actor.Rank == Rank.Civilian && actor.Skills.Intelligence < 65) baseScore -= 15;
+            if (factionStatus.IsAtWar) baseScore += 15;
+            return Clamp0to100(baseScore * cfg.SpyWeight);
+        }
+
+        private static double Clamp0to100(double v) => v < 0 ? 0 : (v > 100 ? 100 : v);
+    }
+}

--- a/Infrastructure/Social/IntentRules/TorturePrisonerIntentRule.cs
+++ b/Infrastructure/Social/IntentRules/TorturePrisonerIntentRule.cs
@@ -1,0 +1,64 @@
+using SkyHorizont.Domain.Entity;
+using SkyHorizont.Domain.Factions;
+using SkyHorizont.Domain.Social;
+using SkyHorizont.Domain.Services;
+
+namespace SkyHorizont.Infrastructure.Social.IntentRules
+{
+    public sealed class TorturePrisonerIntentRule : IIntentRule
+    {
+        private readonly IFactionService _factions;
+        private readonly IRandomService _rng;
+
+        public TorturePrisonerIntentRule(IFactionService factions, IRandomService rng)
+        {
+            _factions = factions;
+            _rng = rng;
+        }
+
+        public IEnumerable<ScoredIntent> Generate(IntentContext ctx)
+        {
+            var target = PickTortureTarget(ctx.Captives, ctx.OpinionOf);
+            if (target == null)
+                yield break;
+
+            var score = ScoreTorture(ctx.Actor, target, ctx.ActorFactionId, ctx.FactionStatus, ctx.FactionOf, ctx.OpinionOf, ctx.Config) * ctx.AmbitionBias.Torture;
+            if (score > 0)
+                yield return new ScoredIntent(IntentType.TorturePrisoner, score, target.Id, null, null);
+        }
+
+        private Character? PickTortureTarget(IReadOnlyList<Character> captives, Func<Guid, int> opin)
+        {
+            if (captives.Count == 0) return null;
+            var pool = captives
+                .Select(c => new { C = c, Score = (int)c.Rank * 10 + c.Skills.Intelligence + _rng.NextInt(0, 20) })
+                .OrderByDescending(x => x.Score)
+                .ToList();
+            return pool.First().C;
+        }
+
+        private double ScoreTorture(Character actor, Character target, Guid actorFactionId, FactionStatus factionStatus, Func<Guid, Guid> fac, Func<Guid, int> opin, PlannerConfig cfg)
+        {
+            var opinion = opin(target.Id);
+            var baseScore = 0.0;
+            baseScore += (50 - actor.Personality.Agreeableness) * 0.4;
+            baseScore += (actor.Personality.Conscientiousness - 50) * 0.2;
+            baseScore += (int)target.Rank * 5;
+            baseScore += target.Skills.Intelligence * 0.3;
+            if (opinion < 0) baseScore += Clamp0to100Map(-opinion) * 0.5;
+            var traits = PersonalityTraits.GetActiveTraits(actor.Personality);
+            foreach (var (traitName, intensity) in traits["Neuroticism"])
+                baseScore += PersonalityTraits.GetTraitEffect(traitName, actor.Personality);
+            baseScore += PersonalityTraits.GetTraitCombinationEffect("ImpulsiveAnger", actor.Personality);
+            var targetFaction = fac(target.Id);
+            if (_factions.IsAtWar(actorFactionId, targetFaction)) baseScore += 15;
+            if (factionStatus.IsAtWar) baseScore += 10;
+            baseScore += (int)actor.Rank * 3;
+            if (actor.Rank < Rank.Captain) baseScore -= 20;
+            return Clamp0to100(baseScore * cfg.TortureWeight);
+        }
+
+        private static double Clamp0to100Map(double v) => Math.Clamp(v, 0, 100);
+        private static double Clamp0to100(double v) => v < 0 ? 0 : (v > 100 ? 100 : v);
+    }
+}

--- a/Infrastructure/Social/IntentRules/TravelIntentRule.cs
+++ b/Infrastructure/Social/IntentRules/TravelIntentRule.cs
@@ -1,0 +1,93 @@
+using SkyHorizont.Domain.Entity;
+using SkyHorizont.Domain.Factions;
+using SkyHorizont.Domain.Galaxy.Planet;
+using SkyHorizont.Domain.Social;
+using SkyHorizont.Domain.Services;
+using SkyHorizont.Domain.Travel;
+
+namespace SkyHorizont.Infrastructure.Social.IntentRules
+{
+    public sealed class TravelIntentRule : IIntentRule
+    {
+        private readonly IPlanetRepository _planets;
+        private readonly IFactionService _factions;
+        private readonly IRandomService _rng;
+
+        public TravelIntentRule(IPlanetRepository planets, IFactionService factions, IRandomService rng)
+        {
+            _planets = planets;
+            _factions = factions;
+            _rng = rng;
+        }
+
+        public IEnumerable<ScoredIntent> Generate(IntentContext ctx)
+        {
+            var dest = PickTravelDestinationPlanet(ctx.Actor, ctx.ActorFactionId, ctx.FactionOf, ctx.OpinionOf);
+            if (!dest.HasValue)
+                yield break;
+
+            var score = ScoreTravel(ctx.Actor, dest.Value, ctx.FactionStatus, ctx.SystemSecurity, ctx.Config) * ctx.AmbitionBias.Travel;
+            if (score > 0)
+                yield return new ScoredIntent(IntentType.TravelToPlanet, score, null, null, dest.Value);
+        }
+
+        private Guid? PickTravelDestinationPlanet(Character actor, Guid actorFactionId, Func<Guid, Guid> fac, Func<Guid, int> opin)
+        {
+            var currentPlanetId = GetCharacterPlanetId(actor.Id);
+            if (!currentPlanetId.HasValue) return null;
+
+            var loved = actor.Relationships
+                .Where(r => r.Type == RelationshipType.Lover || r.Type == RelationshipType.Spouse)
+                .Select(r => r.TargetCharacterId)
+                .Concat(actor.FamilyLinkIds)
+                .Distinct()
+                .ToList();
+
+            var pool = _planets.GetAll()
+                .Where(p => p.Id != currentPlanetId.Value)
+                .Select(p => new
+                {
+                    Planet = p,
+                    Score = (loved.Any(id => p.Citizens.Contains(id) || p.Prisoners.Contains(id)) ? 50 : 0) +
+                            (fac(p.FactionId) == actorFactionId ? 20 : 0) +
+                            (_factions.HasAlliance(actorFactionId, p.FactionId) ? 15 : 0) +
+                            (p.IsTradeHub ? 10 : 0) -
+                            (p.UnrestLevel > 50 ? p.UnrestLevel * 0.1 : 0) +
+                            _rng.NextInt(0, 20)
+                })
+                .OrderByDescending(x => x.Score)
+                .Take(5)
+                .ToList();
+
+            return pool.Count > 0 ? pool[_rng.NextInt(0, pool.Count)].Planet.Id : null;
+        }
+
+        private double ScoreTravel(Character actor, Guid destinationPlanetId, FactionStatus factionStatus, SystemSecurity? systemSecurity, PlannerConfig cfg)
+        {
+            var baseScore = 20.0;
+            baseScore += (actor.Personality.Extraversion - 50) * 0.3;
+            baseScore += (actor.Personality.Openness - 50) * 0.3;
+            var traits = PersonalityTraits.GetActiveTraits(actor.Personality);
+            foreach (var (traitName, intensity) in traits["Extraversion"].Concat(traits["Openness"]))
+                baseScore += PersonalityTraits.GetTraitEffect(traitName, actor.Personality);
+            var destPlanet = _planets.GetById(destinationPlanetId);
+            if (destPlanet != null && destPlanet.UnrestLevel > 50)
+                baseScore -= 10;
+            if (factionStatus.HasAlliance && _factions.GetFactionIdForPlanet(destinationPlanetId) == _factions.GetFactionIdForCharacter(actor.Id))
+                baseScore += 15;
+            if (systemSecurity != null && systemSecurity.PirateActivity > 50)
+                baseScore -= systemSecurity.PirateActivity * 0.1;
+            return Clamp0to100(baseScore * cfg.TravelWeight);
+        }
+
+        private Guid? GetCharacterPlanetId(Guid characterId)
+        {
+            foreach (var p in _planets.GetAll())
+                if (p.Citizens.Contains(characterId) || p.Prisoners.Contains(characterId))
+                    return p.Id;
+            return null;
+        }
+
+        private static double Clamp0to100(double v) => v < 0 ? 0 : (v > 100 ? 100 : v);
+    }
+}

--- a/Infrastructure/Social/IntentRules/VisitFamilyIntentRule.cs
+++ b/Infrastructure/Social/IntentRules/VisitFamilyIntentRule.cs
@@ -1,0 +1,51 @@
+using SkyHorizont.Domain.Entity;
+using SkyHorizont.Domain.Factions;
+using SkyHorizont.Domain.Services;
+using SkyHorizont.Domain.Social;
+
+namespace SkyHorizont.Infrastructure.Social.IntentRules
+{
+    public sealed class VisitFamilyIntentRule : IIntentRule
+    {
+        private readonly IRandomService _rng;
+
+        public VisitFamilyIntentRule(IRandomService rng)
+        {
+            _rng = rng;
+        }
+
+        public IEnumerable<ScoredIntent> Generate(IntentContext ctx)
+        {
+            var target = PickFamilyTarget(ctx.Actor, ctx.OpinionOf);
+            if (!target.HasValue)
+                yield break;
+
+            var score = ScoreVisitFamily(ctx.Actor, target.Value, ctx.FactionStatus, ctx.OpinionOf, ctx.Config) * ctx.AmbitionBias.Family;
+            if (score > 0)
+                yield return new ScoredIntent(IntentType.VisitFamily, score, target.Value, null, null);
+        }
+
+        private Guid? PickFamilyTarget(Character actor, Func<Guid, int> opin)
+        {
+            if (actor.FamilyLinkIds.Count == 0) return null;
+            var weighted = actor.FamilyLinkIds
+                .Select(fid => new { Id = fid, W = opin(fid) + 60 + _rng.NextInt(0, 20) })
+                .OrderByDescending(x => x.W)
+                .FirstOrDefault();
+            return weighted?.Id;
+        }
+
+        private double ScoreVisitFamily(Character actor, Guid familyId, FactionStatus factionStatus, Func<Guid, int> opin, PlannerConfig cfg)
+        {
+            var opinion = opin(familyId);
+            var baseScore = 30.0
+                + Math.Clamp(opinion + 50, 0, 100)
+                + (actor.Personality.Agreeableness - 50) * 0.3
+                + (actor.Personality.Conscientiousness - 50) * 0.2;
+
+            if (factionStatus.HasUnrest)
+                baseScore += 10;
+            return Math.Clamp(baseScore * cfg.FamilyWeight, 0, 100);
+        }
+    }
+}

--- a/Infrastructure/Social/IntentRules/VisitLoverIntentRule.cs
+++ b/Infrastructure/Social/IntentRules/VisitLoverIntentRule.cs
@@ -1,0 +1,85 @@
+using SkyHorizont.Domain.Entity;
+using SkyHorizont.Domain.Factions;
+using SkyHorizont.Domain.Social;
+using SkyHorizont.Domain.Services;
+
+namespace SkyHorizont.Infrastructure.Social.IntentRules
+{
+    public sealed class VisitLoverIntentRule : IIntentRule
+    {
+        private readonly ICharacterRepository _chars;
+        private readonly IFactionService _factions;
+        private readonly IRandomService _rng;
+
+        public VisitLoverIntentRule(ICharacterRepository chars, IFactionService factions, IRandomService rng)
+        {
+            _chars = chars;
+            _factions = factions;
+            _rng = rng;
+        }
+
+        public IEnumerable<ScoredIntent> Generate(IntentContext ctx)
+        {
+            var target = PickLoverTarget(ctx.Actor, ctx.OpinionOf);
+            if (target == null)
+                yield break;
+
+            var score = ScoreVisitLover(ctx.Actor, target, ctx.FactionStatus, ctx.OpinionOf, ctx.FactionOf) * ctx.Config.LoverVisitWeight;
+            if (score > 0)
+                yield return new ScoredIntent(IntentType.VisitLover, score, target.Id, null, null);
+        }
+
+        private Character? PickLoverTarget(Character actor, Func<Guid, int> opin)
+        {
+            if (actor.Relationships.Count == 0)
+                return null;
+
+            var loverIds = actor.Relationships
+                .Where(r => r.Type == RelationshipType.Lover || r.Type == RelationshipType.Spouse)
+                .Select(r => r.TargetCharacterId)
+                .ToHashSet();
+
+            if (loverIds.Count == 0)
+                return null;
+
+            var lovers = _chars.GetByIds(loverIds).Where(c => c.IsAlive).ToList();
+            if (lovers.Count == 0)
+                return null;
+
+            return lovers
+                .Select(c => new { C = c, O = opin(c.Id) + _rng.NextInt(0, 10) })
+                .OrderByDescending(x => x.O)
+                .First().C;
+        }
+
+        private double ScoreVisitLover(Character actor, Character lover, FactionStatus factionStatus, Func<Guid, int> opin, Func<Guid, Guid> fac)
+        {
+            var opinion = opin(lover.Id);
+            double baseScore = 35.0;
+
+            baseScore += Clamp0to100Map(opinion + 50) * 0.5;
+            baseScore += (actor.Personality.Agreeableness - 50) * 0.25;
+            baseScore += (actor.Personality.Extraversion - 50) * 0.20;
+
+            var traits = PersonalityTraits.GetActiveTraits(actor.Personality);
+            foreach (var (traitName, intensity) in traits["Agreeableness"].Concat(traits["Extraversion"]))
+                baseScore += PersonalityTraits.GetTraitEffect(traitName, actor.Personality) * 0.6;
+
+            var actorFactionId = fac(actor.Id);
+            var loverFactionId = fac(lover.Id);
+            if (actorFactionId != Guid.Empty && loverFactionId != Guid.Empty && actorFactionId != loverFactionId)
+                baseScore += 15;
+
+            if (_factions.HasAlliance(actorFactionId, loverFactionId))
+                baseScore += 10;
+
+            if (factionStatus.HasUnrest)
+                baseScore += 5;
+
+            return Clamp0to100(baseScore);
+        }
+
+        private static double Clamp0to100Map(double v) => Math.Clamp(v, 0, 100);
+        private static double Clamp0to100(double v) => v < 0 ? 0 : (v > 100 ? 100 : v);
+    }
+}

--- a/Tests/Common/LifeCycleTest.cs
+++ b/Tests/Common/LifeCycleTest.cs
@@ -2,12 +2,14 @@ using FluentAssertions;
 using Infrastructure.Persistence.Repositories;
 using SkyHorizont.Application.Turns;
 using SkyHorizont.Domain.Factions;
+using SkyHorizont.Domain.Social;
 using SkyHorizont.Domain.Services;
 using SkyHorizont.Infrastructure.DomainServices;
 using SkyHorizont.Infrastructure.Persistence;
 using SkyHorizont.Infrastructure.Persistence.Diplomacy;
 using SkyHorizont.Infrastructure.Repository;
 using SkyHorizont.Infrastructure.Social;
+using SkyHorizont.Infrastructure.Social.IntentRules;
 using SkyHorizont.Infrastructure.Testing;
 using Xunit;
 
@@ -56,7 +58,12 @@ namespace SkyHorizont.Tests.Common
             var merit = new MeritPolicy();
             
             var bus = new InMemoryEventBus();
-            var planner = new IntentPlanner(characters, opinions, faction, rng, planets, fleets, travel, piracy);
+            var rules = new IIntentRule[]
+            {
+                new CourtshipIntentRule(rng),
+                new VisitFamilyIntentRule(rng)
+            };
+            var planner = new IntentPlanner(characters, opinions, faction, rng, planets, fleets, piracy, rules);
             var diplomacy = new DiplomacyService(diplomacies, faction, clock, opinions);
             var resolver = new InteractionResolver(characters, opinions, faction, secrets, rng, diplomacy, travel, piracy, planets, fleets, events, battle, intimacy, merit);
 

--- a/Web/ServiceCollectionExtensions.cs
+++ b/Web/ServiceCollectionExtensions.cs
@@ -21,6 +21,7 @@ using SkyHorizont.Infrastructure.Persistence.Interfaces;
 using SkyHorizont.Infrastructure.Persistence.Intrigue;
 using SkyHorizont.Infrastructure.Repository;
 using SkyHorizont.Infrastructure.Social;
+using SkyHorizont.Infrastructure.Social.IntentRules;
 
 namespace SkyHorizont.Infrastructure.Configuration
 {
@@ -89,6 +90,21 @@ namespace SkyHorizont.Infrastructure.Configuration
             services.AddScoped<ITravelService, TravelService>();
 
 
+            services.AddSingleton<IIntentRule, CourtshipIntentRule>();
+            services.AddSingleton<IIntentRule, VisitFamilyIntentRule>();
+            services.AddSingleton<IIntentRule, VisitLoverIntentRule>();
+            services.AddSingleton<IIntentRule, SpyIntentRule>();
+            services.AddSingleton<IIntentRule, BribeIntentRule>();
+            services.AddSingleton<IIntentRule, RecruitIntentRule>();
+            services.AddSingleton<IIntentRule, DefectIntentRule>();
+            services.AddSingleton<IIntentRule, NegotiateIntentRule>();
+            services.AddSingleton<IIntentRule, QuarrelIntentRule>();
+            services.AddSingleton<IIntentRule, AssassinateIntentRule>();
+            services.AddSingleton<IIntentRule, TorturePrisonerIntentRule>();
+            services.AddSingleton<IIntentRule, RapePrisonerIntentRule>();
+            services.AddSingleton<IIntentRule, TravelIntentRule>();
+            services.AddSingleton<IIntentRule, BecomePirateIntentRule>();
+            services.AddSingleton<IIntentRule, RaidConvoyIntentRule>();
             services.AddSingleton<IIntentPlanner, IntentPlanner>();
             services.AddSingleton<IInteractionResolver, InteractionResolver>();
 


### PR DESCRIPTION
## Summary
- modularize remaining intent types into dedicated `IIntentRule` implementations
- streamline `IntentPlanner` to orchestrate rule execution and add new rules to DI
- adjust lifecycle test for updated planner signature

## Testing
- `dotnet test` *(fails: multiple FleetTests, BattleSimulatorTests, EntityTaskUpdatedTests, LifecycleTests)*

------
https://chatgpt.com/codex/tasks/task_e_68aae86327dc83219162fddfcc0c0d0a