### PR TITLE
Improve child surname assignment

### DIFF
--- a/Tests/Domain/ChildNamingTests.cs
+++ b/Tests/Domain/ChildNamingTests.cs
@@ -1,0 +1,117 @@
+using System;
+using System.Reflection;
+using System.Collections.Generic;
+using FluentAssertions;
+using Xunit;
+using SkyHorizont.Domain.Entity;
+using SkyHorizont.Domain.Services;
+using SkyHorizont.Infrastructure.DomainServices;
+using SkyHorizont.Infrastructure.Persistence.Repositories;
+using SkyHorizont.Infrastructure.Persistence;
+using SkyHorizont.Infrastructure.Testing;
+
+namespace SkyHorizont.Tests.Domain
+{
+    public class ChildNamingTests
+    {
+        [Fact]
+        public void FatherSurnameUsed_WhenParentsAreSpouses()
+        {
+            var service = BuildService();
+            var mother = CharacterFactory.CreateSuperPositive(Guid.NewGuid(), "Aeva Bright", Sex.Female, 22, 2979, 6);
+            var father = CharacterFactory.CreateSuperNegative(Guid.NewGuid(), "Vor Drak", Sex.Male, 24, 2977, 3);
+
+            mother.AddRelationship(father.Id, RelationshipType.Spouse);
+            father.AddRelationship(mother.Id, RelationshipType.Spouse);
+
+            var method = typeof(CharacterLifecycleService).GetMethod("DetermineChildSurname", BindingFlags.NonPublic | BindingFlags.Instance)!;
+            var surname = (string)method.Invoke(service, new object[] { mother, father })!;
+
+            surname.Should().Be("Drak");
+        }
+
+        [Fact]
+        public void MotherSurnameUsed_WhenFatherNotSpouse()
+        {
+            var service = BuildService();
+            var mother = CharacterFactory.CreateSuperPositive(Guid.NewGuid(), "Aeva Bright", Sex.Female, 22, 2979, 6);
+            var father = CharacterFactory.CreateSuperNegative(Guid.NewGuid(), "Vor Drak", Sex.Male, 24, 2977, 3);
+
+            mother.AddRelationship(father.Id, RelationshipType.Lover);
+            father.AddRelationship(mother.Id, RelationshipType.Lover);
+
+            var method = typeof(CharacterLifecycleService).GetMethod("DetermineChildSurname", BindingFlags.NonPublic | BindingFlags.Instance)!;
+            var surname = (string)method.Invoke(service, new object[] { mother, father })!;
+
+            surname.Should().Be("Bright");
+        }
+
+        [Fact]
+        public void MotherSurnameUsed_WhenFatherMissing()
+        {
+            var service = BuildService();
+            var mother = CharacterFactory.CreateSuperPositive(Guid.NewGuid(), "Aeva Bright", Sex.Female, 22, 2979, 6);
+
+            var method = typeof(CharacterLifecycleService).GetMethod("DetermineChildSurname", BindingFlags.NonPublic | BindingFlags.Instance)!;
+            var surname = (string)method.Invoke(service, new object[] { mother, null })!;
+
+            surname.Should().Be("Bright");
+        }
+
+        private static CharacterLifecycleService BuildService()
+        {
+            var characters = new CharactersRepository(new InMemoryCharactersDbContext());
+            var lineage = new LineageRepository(new InMemoryLinageDbContext());
+            var clock = new GameClockService(3001, 1, 1);
+            var rng = new RandomService(123);
+            var mortality = new GompertzMortalityModel();
+            var names = new NameGenerator(rng);
+            var inherit = new SimplePersonalityInheritanceService(rng);
+            var pregPolicy = new DummyPregnancyPolicy();
+            var skillInherit = new SimpleSkillInheritanceService();
+            var loc = new DummyLocationService();
+            var events = new DummyEventBus();
+            var intimacy = new DummyIntimacyLog();
+
+            return new CharacterLifecycleService(
+                characters, lineage, clock, rng, mortality, names, inherit,
+                pregPolicy, skillInherit, loc, events, intimacy);
+        }
+
+        private sealed class DummyPregnancyPolicy : IPregnancyPolicy
+        {
+            public bool ShouldHaveTwins(Character mother, int year, int month) => false;
+            public bool ShouldHaveComplications(Character mother, int year, int month, out string? note) { note = null; return false; }
+            public bool IsPostpartumProtected(Character mother, int year, int month) => false;
+            public void RecordDelivery(Guid motherId, int year, int month) { }
+            public bool CanConceiveWith(Character potentialMother, Character partner, int year, int month) => false;
+        }
+
+        private sealed class DummyLocationService : ILocationService
+        {
+            public CharacterLocation? GetCharacterLocation(Guid characterId) => null;
+            public bool AreCoLocated(Guid characterA, Guid characterB) => false;
+            public bool AreInSameSystem(Guid characterA, Guid characterB) => false;
+            public IEnumerable<Guid> GetCharactersOnPlanet(Guid planetId) => Array.Empty<Guid>();
+            public IEnumerable<Guid> GetCharactersOnFleet(Guid fleetId) => Array.Empty<Guid>();
+            public IEnumerable<Guid> GetCaptivesOnPlanet(Guid planetId) => Array.Empty<Guid>();
+            public IEnumerable<Guid> GetCaptivesOnFleet(Guid fleetId) => Array.Empty<Guid>();
+            public void AddCitizenToPlanet(Guid character, Guid locationId) { }
+            public void AddPassengerToFleet(Guid character, Guid fleetId) { }
+            public void StageAtHolding(Guid character, Guid locationId) { }
+            public bool IsPrisonerOf(Guid prisonerId, Guid captorId) => false;
+        }
+
+        private sealed class DummyEventBus : IEventBus
+        {
+            public void Publish<T>(T @event) { }
+        }
+
+        private sealed class DummyIntimacyLog : IIntimacyLog
+        {
+            public void RecordIntimacyEncounter(Guid charA, Guid charB, int year, int month) { }
+            public IReadOnlyList<Guid> GetPartnersForMother(Guid motherId, int year, int month) => Array.Empty<Guid>();
+            public void PurgeOlderThan(int year, int month) { }
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- ensure children take father's surname only when parents are married
- add tests for married and unmarried father scenarios

## Testing
- `dotnet test -q -p:ImplicitUsings=disable -p:UseSharedCompilation=false` *(fails: MSB3492: Could not read existing file "obj/Debug/net8.0/Domain.csproj.FileListAbsolute.txt" to determine whether its contents are up to date. Overwriting it.)*

------
https://chatgpt.com/codex/tasks/task_e_68aaf08ede2083219f72ae141af8bb6f