### PR TITLE
Fix piracy registration compile issues and update tests

### DIFF
--- a/Infrastructure/DomainServices/CharacterLifecycleService.cs
+++ b/Infrastructure/DomainServices/CharacterLifecycleService.cs
@@ -202,6 +202,7 @@ namespace SkyHorizont.Infrastructure.DomainServices
 
             var babySkills = _skillInherit.Inherit(mother.Skills, father?.Skills, _rng);
 
+
             var loc = _loc.GetCharacterLocation(mother.Id);
             (babyPersonality, babySkills) = ApplyBirthVariance(babyPersonality, babySkills, loc);
 
@@ -226,7 +227,7 @@ namespace SkyHorizont.Infrastructure.DomainServices
             }
             _characters.Save(mother);
 
-            var loc = _loc.GetCharacterLocation(mother.Id);
+            loc = _loc.GetCharacterLocation(mother.Id);
             if (loc != null)
             {
                 switch (loc.Kind)
@@ -243,8 +244,8 @@ namespace SkyHorizont.Infrastructure.DomainServices
                 }
             }
 
-            var motherFaction =_factions.GetFaction(mother.Id);
-            _factions.MoveCharacterToFaction(babyId, motherFaction.Id);
+            var motherFactionId = _factions.GetFactionIdForCharacter(mother.Id);
+            _factions.MoveCharacterToFaction(babyId, motherFactionId);
 
             return baby;
         }

--- a/Infrastructure/DomainServices/PiracyService.cs
+++ b/Infrastructure/DomainServices/PiracyService.cs
@@ -8,7 +8,7 @@ namespace SkyHorizont.Infrastructure.DomainServices
     {
         private readonly IFactionService _factions;
         private readonly IRandomService _rng;
-        private readonly Guid _pirateFactionId;
+        private Guid _pirateFactionId;
 
         // simple in-memory state
         private readonly Dictionary<Guid, int> _pirateActivityBySystem = new(); // 0..100
@@ -75,5 +75,11 @@ namespace SkyHorizont.Infrastructure.DomainServices
         }
 
         public Guid GetPirateFactionId() => _pirateFactionId;
+
+        public void RegisterPirateFaction(Guid id)
+        {
+            if (id == Guid.Empty) return;
+            _pirateFactionId = id;
+        }
     }
 }

--- a/Infrastructure/Social/InteractionResolver.cs
+++ b/Infrastructure/Social/InteractionResolver.cs
@@ -957,7 +957,7 @@ namespace SkyHorizont.Infrastructure.Social
             if (factionStatus.HasUnrest) baseChance += 0.15;
             if (actor.Ambition == CharacterAmbition.SeekAdventure) baseChance += 0.15;
 
-            var actorSystemId = FindSystemOfCharacter(actor.Id);
+            var actorSystemId = GetSystemOfCharacter(actor.Id);
             if (actorSystemId.HasValue)
             {
                 var sec = GetSystemSecurity(actorSystemId.Value);
@@ -1444,6 +1444,13 @@ namespace SkyHorizont.Infrastructure.Social
 
         private Guid? GetSystemOfCharacter(Guid characterId)
             => GetCharacterLocation(characterId).SystemId;
+
+        private Guid? PickLocalPirateClan(Guid systemId)
+        {
+            // Currently no local pirate tracking; always prefer global faction
+            // or create a new one when none exists.
+            return null;
+        }
 
         private (Guid? PlanetId, Guid? SystemId) GetCharacterLocation(Guid characterId)
         {

--- a/Tests/Common/LifeCycleTest.cs
+++ b/Tests/Common/LifeCycleTest.cs
@@ -69,7 +69,7 @@ namespace SkyHorizont.Tests.Common
 
             var lifecycle = new CharacterLifecycleService(
                 characters, lineage, clock, rng, mortality, nameGen,
-                inherit, pregPolicy, skillInh, loc, bus, intimacy);
+                inherit, pregPolicy, skillInh, loc, bus, intimacy, faction);
 
             var runner = new LifecycleSimulationRunner(characters, lineage, planets, lifecycle, planner, resolver, socialLog, clock, affection);
 

--- a/Tests/Domain/ChildInheritanceVariationTests.cs
+++ b/Tests/Domain/ChildInheritanceVariationTests.cs
@@ -4,9 +4,12 @@ using FluentAssertions;
 using Xunit;
 using SkyHorizont.Domain.Entity;
 using SkyHorizont.Domain.Services;
+using SkyHorizont.Domain.Factions;
 using SkyHorizont.Infrastructure.DomainServices;
-using SkyHorizont.Infrastructure.Persistence.Repositories;
 using SkyHorizont.Infrastructure.Persistence;
+using SkyHorizont.Infrastructure.Repository;
+using SkyHorizont.Application.Turns;
+using System.Collections.Generic;
 
 namespace SkyHorizont.Tests.Domain
 {
@@ -61,7 +64,7 @@ namespace SkyHorizont.Tests.Domain
 
             return new CharacterLifecycleService(
                 characters, lineage, clock, rng, mortality, names, inherit,
-                pregPolicy, skillInherit, loc, events, intimacy);
+                pregPolicy, skillInherit, loc, events, intimacy, new DummyFactionService());
         }
 
         private sealed class DummyPregnancyPolicy : IPregnancyPolicy
@@ -83,6 +86,21 @@ namespace SkyHorizont.Tests.Domain
             public void RecordIntimacyEncounter(Guid charA, Guid charB, int year, int month) { }
             public IReadOnlyList<Guid> GetPartnersForMother(Guid motherId, int year, int month) => Array.Empty<Guid>();
             public void PurgeOlderThan(int year, int month) { }
+        }
+
+        private sealed class DummyFactionService : IFactionService
+        {
+            public Guid GetFactionIdForCharacter(Guid characterId) => Guid.Empty;
+            public Guid GetFactionIdForPlanet(Guid planetId) => Guid.Empty;
+            public Guid GetFactionIdForSystem(Guid systemId) => Guid.Empty;
+            public Guid? GetLeaderId(Guid factionId) => null;
+            public bool IsAtWar(Guid a, Guid b) => false;
+            public IEnumerable<Guid> GetAllRivalFactions(Guid forFaction) => Array.Empty<Guid>();
+            public bool HasAlliance(Guid factionA, Guid factionB) => false;
+            public int GetEconomicStrength(Guid factionId) => 0;
+            public void MoveCharacterToFaction(Guid characterId, Guid newFactionId) { }
+            public void Save(Faction faction) { }
+            public Faction GetFaction(Guid factionId) => new Faction(factionId, "Dummy", Guid.Empty);
         }
 
         private sealed class FixedLocationService : ILocationService

--- a/Tests/Domain/ChildNamingTests.cs
+++ b/Tests/Domain/ChildNamingTests.cs
@@ -6,9 +6,11 @@ using Xunit;
 using SkyHorizont.Domain.Entity;
 using SkyHorizont.Domain.Services;
 using SkyHorizont.Infrastructure.DomainServices;
-using SkyHorizont.Infrastructure.Persistence.Repositories;
 using SkyHorizont.Infrastructure.Persistence;
 using SkyHorizont.Infrastructure.Testing;
+using SkyHorizont.Infrastructure.Repository;
+using SkyHorizont.Domain.Factions;
+using SkyHorizont.Application.Turns;
 
 namespace SkyHorizont.Tests.Domain
 {
@@ -75,7 +77,7 @@ namespace SkyHorizont.Tests.Domain
 
             return new CharacterLifecycleService(
                 characters, lineage, clock, rng, mortality, names, inherit,
-                pregPolicy, skillInherit, loc, events, intimacy);
+                pregPolicy, skillInherit, loc, events, intimacy, new DummyFactionService());
         }
 
         private sealed class DummyPregnancyPolicy : IPregnancyPolicy
@@ -112,6 +114,21 @@ namespace SkyHorizont.Tests.Domain
             public void RecordIntimacyEncounter(Guid charA, Guid charB, int year, int month) { }
             public IReadOnlyList<Guid> GetPartnersForMother(Guid motherId, int year, int month) => Array.Empty<Guid>();
             public void PurgeOlderThan(int year, int month) { }
+        }
+
+        private sealed class DummyFactionService : IFactionService
+        {
+            public Guid GetFactionIdForCharacter(Guid characterId) => Guid.Empty;
+            public Guid GetFactionIdForPlanet(Guid planetId) => Guid.Empty;
+            public Guid GetFactionIdForSystem(Guid systemId) => Guid.Empty;
+            public Guid? GetLeaderId(Guid factionId) => null;
+            public bool IsAtWar(Guid a, Guid b) => false;
+            public IEnumerable<Guid> GetAllRivalFactions(Guid forFaction) => Array.Empty<Guid>();
+            public bool HasAlliance(Guid factionA, Guid factionB) => false;
+            public int GetEconomicStrength(Guid factionId) => 0;
+            public void MoveCharacterToFaction(Guid characterId, Guid newFactionId) { }
+            public void Save(Faction faction) { }
+            public Faction GetFaction(Guid factionId) => new Faction(factionId, "Dummy", Guid.Empty);
         }
     }
 }


### PR DESCRIPTION
## Summary
- Implement `RegisterPirateFaction` in `PiracyService` and allow pirate faction id to be updated
- Correct newborn location handling and faction assignment in `CharacterLifecycleService`
- Replace outdated helpers in `InteractionResolver` and add stub for `PickLocalPirateClan`
- Update tests with dummy faction services and correct namespaces

## Testing
- `dotnet test`

------
https://chatgpt.com/codex/tasks/task_e_68ac163fb58c8321941f168d192b52df