### PR TITLE
Use dictionary for intent ambition multipliers

### DIFF
--- a/Domain/Social/IntentContext.cs
+++ b/Domain/Social/IntentContext.cs
@@ -2,6 +2,7 @@ using SkyHorizont.Domain.Entity;
 using SkyHorizont.Domain.Factions;
 using SkyHorizont.Domain.Galaxy.Planet;
 using SkyHorizont.Domain.Travel;
+using System.Collections.Generic;
 
 namespace SkyHorizont.Domain.Social
 {
@@ -18,7 +19,7 @@ namespace SkyHorizont.Domain.Social
         public IReadOnlyList<Character> OtherFactionCharacters { get; }
         public IReadOnlyList<Character> Captives { get; }
         public CharacterAmbition Ambition { get; }
-        public (double Court, double Family, double Spy, double Bribe, double Recruit, double Defect, double Negotiate, double Quarrel, double Assassinate, double Torture, double Rape, double Travel, double BecomePirate, double RaidConvoy) AmbitionBias { get; }
+        public IReadOnlyDictionary<IntentType, double> AmbitionBias { get; }
         public Func<Guid, int> OpinionOf { get; }
         public Func<Guid, Guid> FactionOf { get; }
         public PlannerConfig Config { get; }
@@ -34,7 +35,7 @@ namespace SkyHorizont.Domain.Social
             IReadOnlyList<Character> otherFactionCharacters,
             IReadOnlyList<Character> captives,
             CharacterAmbition ambition,
-            (double Court, double Family, double Spy, double Bribe, double Recruit, double Defect, double Negotiate, double Quarrel, double Assassinate, double Torture, double Rape, double Travel, double BecomePirate, double RaidConvoy) ambitionBias,
+            IReadOnlyDictionary<IntentType, double> ambitionBias,
             Func<Guid, int> opinionOf,
             Func<Guid, Guid> factionOf,
             PlannerConfig config)

--- a/Infrastructure/DomainServices/PiracyService.cs
+++ b/Infrastructure/DomainServices/PiracyService.cs
@@ -75,5 +75,11 @@ namespace SkyHorizont.Infrastructure.DomainServices
         }
 
         public Guid GetPirateFactionId() => _pirateFactionId;
+
+        public void RegisterPirateFaction(Guid id)
+        {
+            // current implementation supports only a single pirate faction
+            // additional factions can be registered in future enhancements
+        }
     }
 }

--- a/Infrastructure/Social/IntentPlanner.cs
+++ b/Infrastructure/Social/IntentPlanner.cs
@@ -214,16 +214,79 @@ namespace SkyHorizont.Infrastructure.Social
             return security;
         }
 
-        private (double Court, double Family, double Spy, double Bribe, double Recruit, double Defect, double Negotiate, double Quarrel, double Assassinate, double Torture, double Rape, double Travel, double BecomePirate, double RaidConvoy) GetAmbitionBias(CharacterAmbition ambition)
+        private IReadOnlyDictionary<IntentType, double> GetAmbitionBias(CharacterAmbition ambition)
         {
-            return ambition switch
+            var bias = Enum.GetValues<IntentType>().ToDictionary(t => t, _ => 1.0);
+
+            switch (ambition)
             {
-                CharacterAmbition.GainPower => (0.8, 0.7, 1.2, 1.1, 1.2, 1.3, 1.0, 1.0, 1.3, 1.0, 0.9, 0.8, 0.9, 0.8),
-                CharacterAmbition.BuildWealth => (0.9, 0.8, 1.1, 1.3, 1.1, 0.8, 1.2, 0.7, 0.8, 0.7, 0.6, 1.0, 1.2, 1.3),
-                CharacterAmbition.EnsureFamilyLegacy => (1.2, 1.3, 0.8, 0.9, 0.9, 0.7, 0.9, 0.8, 0.7, 0.6, 0.5, 1.1, 0.7, 0.6),
-                CharacterAmbition.SeekAdventure => (0.9, 0.8, 1.2, 0.9, 0.9, 1.0, 0.9, 1.0, 1.0, 0.8, 0.7, 1.3, 1.2, 1.2),
-                _ => (1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0)
-            };
+                case CharacterAmbition.GainPower:
+                    bias[IntentType.Court] = 0.8;
+                    bias[IntentType.VisitFamily] = 0.7;
+                    bias[IntentType.Spy] = 1.2;
+                    bias[IntentType.Bribe] = 1.1;
+                    bias[IntentType.Recruit] = 1.2;
+                    bias[IntentType.Defect] = 1.3;
+                    bias[IntentType.Negotiate] = 1.0;
+                    bias[IntentType.Quarrel] = 1.0;
+                    bias[IntentType.Assassinate] = 1.3;
+                    bias[IntentType.TorturePrisoner] = 1.0;
+                    bias[IntentType.RapePrisoner] = 0.9;
+                    bias[IntentType.TravelToPlanet] = 0.8;
+                    bias[IntentType.BecomePirate] = 0.9;
+                    bias[IntentType.RaidConvoy] = 0.8;
+                    break;
+                case CharacterAmbition.BuildWealth:
+                    bias[IntentType.Court] = 0.9;
+                    bias[IntentType.VisitFamily] = 0.8;
+                    bias[IntentType.Spy] = 1.1;
+                    bias[IntentType.Bribe] = 1.3;
+                    bias[IntentType.Recruit] = 1.1;
+                    bias[IntentType.Defect] = 0.8;
+                    bias[IntentType.Negotiate] = 1.2;
+                    bias[IntentType.Quarrel] = 0.7;
+                    bias[IntentType.Assassinate] = 0.8;
+                    bias[IntentType.TorturePrisoner] = 0.7;
+                    bias[IntentType.RapePrisoner] = 0.6;
+                    bias[IntentType.TravelToPlanet] = 1.0;
+                    bias[IntentType.BecomePirate] = 1.2;
+                    bias[IntentType.RaidConvoy] = 1.3;
+                    break;
+                case CharacterAmbition.EnsureFamilyLegacy:
+                    bias[IntentType.Court] = 1.2;
+                    bias[IntentType.VisitFamily] = 1.3;
+                    bias[IntentType.Spy] = 0.8;
+                    bias[IntentType.Bribe] = 0.9;
+                    bias[IntentType.Recruit] = 0.9;
+                    bias[IntentType.Defect] = 0.7;
+                    bias[IntentType.Negotiate] = 0.9;
+                    bias[IntentType.Quarrel] = 0.8;
+                    bias[IntentType.Assassinate] = 0.7;
+                    bias[IntentType.TorturePrisoner] = 0.6;
+                    bias[IntentType.RapePrisoner] = 0.5;
+                    bias[IntentType.TravelToPlanet] = 1.1;
+                    bias[IntentType.BecomePirate] = 0.7;
+                    bias[IntentType.RaidConvoy] = 0.6;
+                    break;
+                case CharacterAmbition.SeekAdventure:
+                    bias[IntentType.Court] = 0.9;
+                    bias[IntentType.VisitFamily] = 0.8;
+                    bias[IntentType.Spy] = 1.2;
+                    bias[IntentType.Bribe] = 0.9;
+                    bias[IntentType.Recruit] = 0.9;
+                    bias[IntentType.Defect] = 1.0;
+                    bias[IntentType.Negotiate] = 0.9;
+                    bias[IntentType.Quarrel] = 1.0;
+                    bias[IntentType.Assassinate] = 1.0;
+                    bias[IntentType.TorturePrisoner] = 0.8;
+                    bias[IntentType.RapePrisoner] = 0.7;
+                    bias[IntentType.TravelToPlanet] = 1.3;
+                    bias[IntentType.BecomePirate] = 1.2;
+                    bias[IntentType.RaidConvoy] = 1.2;
+                    break;
+            }
+
+            return bias;
         }
 
         private List<ScoredIntent> ResolveConflictsTargetAware(Character actor, List<ScoredIntent> candidates, int take, Func<Guid, Guid> fac)

--- a/Infrastructure/Social/IntentRules/AssassinateIntentRule.cs
+++ b/Infrastructure/Social/IntentRules/AssassinateIntentRule.cs
@@ -22,7 +22,7 @@ namespace SkyHorizont.Infrastructure.Social.IntentRules
             if (target == null)
                 yield break;
 
-            var score = ScoreAssassinate(ctx.Actor, target, ctx.ActorFactionId, ctx.FactionStatus, ctx.FactionOf, ctx.OpinionOf, ctx.Config) * ctx.AmbitionBias.Assassinate;
+            var score = ScoreAssassinate(ctx.Actor, target, ctx.ActorFactionId, ctx.FactionStatus, ctx.FactionOf, ctx.OpinionOf, ctx.Config) * ctx.AmbitionBias[IntentType.Assassinate];
             if (score > 0)
                 yield return new ScoredIntent(IntentType.Assassinate, score, target.Id, null, null);
         }

--- a/Infrastructure/Social/IntentRules/BecomePirateIntentRule.cs
+++ b/Infrastructure/Social/IntentRules/BecomePirateIntentRule.cs
@@ -23,7 +23,7 @@ namespace SkyHorizont.Infrastructure.Social.IntentRules
             if (_piracy.IsPirateFaction(ctx.ActorFactionId))
                 yield break;
 
-            var score = ScoreBecomePirate(ctx.Actor, ctx.ActorFactionId, ctx.ActorLeaderId, ctx.SystemSecurity, ctx.OpinionOf, ctx.FactionStatus, ctx.Config) * ctx.AmbitionBias.BecomePirate;
+            var score = ScoreBecomePirate(ctx.Actor, ctx.ActorFactionId, ctx.ActorLeaderId, ctx.SystemSecurity, ctx.OpinionOf, ctx.FactionStatus, ctx.Config) * ctx.AmbitionBias[IntentType.BecomePirate];
             if (score > 0)
                 yield return new ScoredIntent(IntentType.BecomePirate, score, null, null, null);
         }

--- a/Infrastructure/Social/IntentRules/BribeIntentRule.cs
+++ b/Infrastructure/Social/IntentRules/BribeIntentRule.cs
@@ -22,7 +22,7 @@ namespace SkyHorizont.Infrastructure.Social.IntentRules
             if (target == null)
                 yield break;
 
-            var score = ScoreBribe(ctx.Actor, target, ctx.ActorFactionId, ctx.FactionStatus, ctx.FactionOf, ctx.Config) * ctx.AmbitionBias.Bribe;
+            var score = ScoreBribe(ctx.Actor, target, ctx.ActorFactionId, ctx.FactionStatus, ctx.FactionOf, ctx.Config) * ctx.AmbitionBias[IntentType.Bribe];
             if (score > 0)
                 yield return new ScoredIntent(IntentType.Bribe, score, target.Id, null, null);
         }

--- a/Infrastructure/Social/IntentRules/CourtshipIntentRule.cs
+++ b/Infrastructure/Social/IntentRules/CourtshipIntentRule.cs
@@ -21,7 +21,7 @@ namespace SkyHorizont.Infrastructure.Social.IntentRules
             if (target == null)
                 yield break;
 
-            var score = ScoreCourtship(ctx.Actor, target, ctx.FactionStatus, ctx.OpinionOf, ctx.Config) * ctx.AmbitionBias.Court;
+            var score = ScoreCourtship(ctx.Actor, target, ctx.FactionStatus, ctx.OpinionOf, ctx.Config) * ctx.AmbitionBias[IntentType.Court];
             if (score > 0)
                 yield return new ScoredIntent(IntentType.Court, score, target.Id, null, null);
         }

--- a/Infrastructure/Social/IntentRules/DefectIntentRule.cs
+++ b/Infrastructure/Social/IntentRules/DefectIntentRule.cs
@@ -25,7 +25,7 @@ namespace SkyHorizont.Infrastructure.Social.IntentRules
             if (targetFaction == Guid.Empty)
                 yield break;
 
-            var score = ScoreDefect(ctx.Actor, ctx.ActorLeaderId.Value, ctx.ActorFactionId, targetFaction, ctx.FactionStatus, ctx.OpinionOf, ctx.Config) * ctx.AmbitionBias.Defect;
+            var score = ScoreDefect(ctx.Actor, ctx.ActorLeaderId.Value, ctx.ActorFactionId, targetFaction, ctx.FactionStatus, ctx.OpinionOf, ctx.Config) * ctx.AmbitionBias[IntentType.Defect];
             if (score > 0)
                 yield return new ScoredIntent(IntentType.Defect, score, null, targetFaction, null);
         }

--- a/Infrastructure/Social/IntentRules/NegotiateIntentRule.cs
+++ b/Infrastructure/Social/IntentRules/NegotiateIntentRule.cs
@@ -22,7 +22,7 @@ namespace SkyHorizont.Infrastructure.Social.IntentRules
             if (targetFaction == Guid.Empty)
                 yield break;
 
-            var score = ScoreNegotiate(ctx.Actor, ctx.ActorFactionId, targetFaction, ctx.FactionStatus, ctx.Config) * ctx.AmbitionBias.Negotiate;
+            var score = ScoreNegotiate(ctx.Actor, ctx.ActorFactionId, targetFaction, ctx.FactionStatus, ctx.Config) * ctx.AmbitionBias[IntentType.Negotiate];
             if (score > 0)
                 yield return new ScoredIntent(IntentType.Negotiate, score, null, targetFaction, null);
         }

--- a/Infrastructure/Social/IntentRules/QuarrelIntentRule.cs
+++ b/Infrastructure/Social/IntentRules/QuarrelIntentRule.cs
@@ -20,7 +20,7 @@ namespace SkyHorizont.Infrastructure.Social.IntentRules
             if (target == null)
                 yield break;
 
-            var score = ScoreQuarrel(ctx.Actor, target, ctx.FactionStatus, ctx.OpinionOf, ctx.Config) * ctx.AmbitionBias.Quarrel;
+            var score = ScoreQuarrel(ctx.Actor, target, ctx.FactionStatus, ctx.OpinionOf, ctx.Config) * ctx.AmbitionBias[IntentType.Quarrel];
             if (score > 0)
                 yield return new ScoredIntent(IntentType.Quarrel, score, target.Id, null, null);
         }

--- a/Infrastructure/Social/IntentRules/RaidConvoyIntentRule.cs
+++ b/Infrastructure/Social/IntentRules/RaidConvoyIntentRule.cs
@@ -32,7 +32,7 @@ namespace SkyHorizont.Infrastructure.Social.IntentRules
                 yield break;
 
             var security = GetSystemSecurity(targetSystem.Value);
-            var score = ScoreRaidConvoy(ctx.Actor, targetSystem.Value, security, ctx.Config) * ctx.AmbitionBias.RaidConvoy;
+            var score = ScoreRaidConvoy(ctx.Actor, targetSystem.Value, security, ctx.Config) * ctx.AmbitionBias[IntentType.RaidConvoy];
             if (score > 0)
                 yield return new ScoredIntent(IntentType.RaidConvoy, score, null, targetSystem.Value, null);
         }

--- a/Infrastructure/Social/IntentRules/RapePrisonerIntentRule.cs
+++ b/Infrastructure/Social/IntentRules/RapePrisonerIntentRule.cs
@@ -22,7 +22,7 @@ namespace SkyHorizont.Infrastructure.Social.IntentRules
             if (target == null)
                 yield break;
 
-            var score = ScoreRape(ctx.Actor, target, ctx.ActorFactionId, ctx.FactionStatus, ctx.FactionOf, ctx.OpinionOf, ctx.Config) * ctx.AmbitionBias.Rape;
+            var score = ScoreRape(ctx.Actor, target, ctx.ActorFactionId, ctx.FactionStatus, ctx.FactionOf, ctx.OpinionOf, ctx.Config) * ctx.AmbitionBias[IntentType.RapePrisoner];
             if (score > 0)
                 yield return new ScoredIntent(IntentType.RapePrisoner, score, target.Id, null, null);
         }

--- a/Infrastructure/Social/IntentRules/RecruitIntentRule.cs
+++ b/Infrastructure/Social/IntentRules/RecruitIntentRule.cs
@@ -31,7 +31,7 @@ namespace SkyHorizont.Infrastructure.Social.IntentRules
             if (target == null)
                 yield break;
 
-            var score = ScoreRecruit(ctx.Actor, target, ctx.ActorFactionId, ctx.FactionStatus, ctx.FactionOf, ctx.OpinionOf, ctx.Config) * ctx.AmbitionBias.Recruit;
+            var score = ScoreRecruit(ctx.Actor, target, ctx.ActorFactionId, ctx.FactionStatus, ctx.FactionOf, ctx.OpinionOf, ctx.Config) * ctx.AmbitionBias[IntentType.Recruit];
             if (score > 0)
                 yield return new ScoredIntent(IntentType.Recruit, score, target.Id, null, null);
         }

--- a/Infrastructure/Social/IntentRules/SpyIntentRule.cs
+++ b/Infrastructure/Social/IntentRules/SpyIntentRule.cs
@@ -18,7 +18,7 @@ namespace SkyHorizont.Infrastructure.Social.IntentRules
 
         public IEnumerable<ScoredIntent> Generate(IntentContext ctx)
         {
-            var scoreBase = ScoreSpy(ctx.Actor, ctx.FactionStatus, ctx.Config) * ctx.AmbitionBias.Spy;
+            var scoreBase = ScoreSpy(ctx.Actor, ctx.FactionStatus, ctx.Config) * ctx.AmbitionBias[IntentType.Spy];
             if (scoreBase <= 0)
                 yield break;
 

--- a/Infrastructure/Social/IntentRules/TorturePrisonerIntentRule.cs
+++ b/Infrastructure/Social/IntentRules/TorturePrisonerIntentRule.cs
@@ -22,7 +22,7 @@ namespace SkyHorizont.Infrastructure.Social.IntentRules
             if (target == null)
                 yield break;
 
-            var score = ScoreTorture(ctx.Actor, target, ctx.ActorFactionId, ctx.FactionStatus, ctx.FactionOf, ctx.OpinionOf, ctx.Config) * ctx.AmbitionBias.Torture;
+            var score = ScoreTorture(ctx.Actor, target, ctx.ActorFactionId, ctx.FactionStatus, ctx.FactionOf, ctx.OpinionOf, ctx.Config) * ctx.AmbitionBias[IntentType.TorturePrisoner];
             if (score > 0)
                 yield return new ScoredIntent(IntentType.TorturePrisoner, score, target.Id, null, null);
         }

--- a/Infrastructure/Social/IntentRules/TravelIntentRule.cs
+++ b/Infrastructure/Social/IntentRules/TravelIntentRule.cs
@@ -26,7 +26,7 @@ namespace SkyHorizont.Infrastructure.Social.IntentRules
             if (!dest.HasValue)
                 yield break;
 
-            var score = ScoreTravel(ctx.Actor, dest.Value, ctx.FactionStatus, ctx.SystemSecurity, ctx.Config) * ctx.AmbitionBias.Travel;
+            var score = ScoreTravel(ctx.Actor, dest.Value, ctx.FactionStatus, ctx.SystemSecurity, ctx.Config) * ctx.AmbitionBias[IntentType.TravelToPlanet];
             if (score > 0)
                 yield return new ScoredIntent(IntentType.TravelToPlanet, score, null, null, dest.Value);
         }

--- a/Infrastructure/Social/IntentRules/VisitFamilyIntentRule.cs
+++ b/Infrastructure/Social/IntentRules/VisitFamilyIntentRule.cs
@@ -20,7 +20,7 @@ namespace SkyHorizont.Infrastructure.Social.IntentRules
             if (!target.HasValue)
                 yield break;
 
-            var score = ScoreVisitFamily(ctx.Actor, target.Value, ctx.FactionStatus, ctx.OpinionOf, ctx.Config) * ctx.AmbitionBias.Family;
+            var score = ScoreVisitFamily(ctx.Actor, target.Value, ctx.FactionStatus, ctx.OpinionOf, ctx.Config) * ctx.AmbitionBias[IntentType.VisitFamily];
             if (score > 0)
                 yield return new ScoredIntent(IntentType.VisitFamily, score, target.Value, null, null);
         }


### PR DESCRIPTION
## Summary
- switch `IntentContext` ambition bias from fixed tuple to intent-keyed dictionary
- compute bias dictionary in `IntentPlanner` and update intent rules to use it
- add stub `RegisterPirateFaction` method so `PiracyService` matches interface

## Testing
- `dotnet test` *(fails: CharacterLifecycleService.cs(229,17): 'loc' already defined; InteractionResolver.cs missing methods)*

------
https://chatgpt.com/codex/tasks/task_e_68ac183f33b0832185de15f37d304eed