### PR TITLE
refactor: replace ambition bias tuple with record

### DIFF
--- a/Domain/Social/AmbitionBias.cs
+++ b/Domain/Social/AmbitionBias.cs
@@ -1,0 +1,50 @@
+namespace SkyHorizont.Domain.Social;
+
+public sealed record AmbitionBias
+{
+    public double Court { get; init; } = 1.0;
+    public double Quarrel { get; init; } = 1.0;
+    public double Gift { get; init; } = 1.0;
+    public double Recruit { get; init; } = 1.0;
+    public double Bribe { get; init; } = 1.0;
+    public double Spy { get; init; } = 1.0;
+    public double Defect { get; init; } = 1.0;
+    public double Assassinate { get; init; } = 1.0;
+    public double Negotiate { get; init; } = 1.0;
+    public double VisitFamily { get; init; } = 1.0;
+    public double VisitLover { get; init; } = 1.0;
+    public double TorturePrisoner { get; init; } = 1.0;
+    public double RapePrisoner { get; init; } = 1.0;
+    public double TravelToPlanet { get; init; } = 1.0;
+    public double BecomePirate { get; init; } = 1.0;
+    public double RaidConvoy { get; init; } = 1.0;
+    public double FoundHouse { get; init; } = 1.0;
+    public double FoundPirateClan { get; init; } = 1.0;
+    public double ExpelFromHouse { get; init; } = 1.0;
+    public double ClaimPlanetSeat { get; init; } = 1.0;
+
+    public double this[IntentType intent] => intent switch
+    {
+        IntentType.Court => Court,
+        IntentType.Quarrel => Quarrel,
+        IntentType.Gift => Gift,
+        IntentType.Recruit => Recruit,
+        IntentType.Bribe => Bribe,
+        IntentType.Spy => Spy,
+        IntentType.Defect => Defect,
+        IntentType.Assassinate => Assassinate,
+        IntentType.Negotiate => Negotiate,
+        IntentType.VisitFamily => VisitFamily,
+        IntentType.VisitLover => VisitLover,
+        IntentType.TorturePrisoner => TorturePrisoner,
+        IntentType.RapePrisoner => RapePrisoner,
+        IntentType.TravelToPlanet => TravelToPlanet,
+        IntentType.BecomePirate => BecomePirate,
+        IntentType.RaidConvoy => RaidConvoy,
+        IntentType.FoundHouse => FoundHouse,
+        IntentType.FoundPirateClan => FoundPirateClan,
+        IntentType.ExpelFromHouse => ExpelFromHouse,
+        IntentType.ClaimPlanetSeat => ClaimPlanetSeat,
+        _ => 1.0
+    };
+}

--- a/Domain/Social/IntentContext.cs
+++ b/Domain/Social/IntentContext.cs
@@ -19,7 +19,7 @@ namespace SkyHorizont.Domain.Social
         public IReadOnlyList<Character> OtherFactionCharacters { get; }
         public IReadOnlyList<Character> Captives { get; }
         public CharacterAmbition Ambition { get; }
-        public IReadOnlyDictionary<IntentType, double> AmbitionBias { get; }
+        public AmbitionBias AmbitionBias { get; }
         public Func<Guid, int> OpinionOf { get; }
         public Func<Guid, Guid> FactionOf { get; }
         public PlannerConfig Config { get; }
@@ -35,7 +35,7 @@ namespace SkyHorizont.Domain.Social
             IReadOnlyList<Character> otherFactionCharacters,
             IReadOnlyList<Character> captives,
             CharacterAmbition ambition,
-            IReadOnlyDictionary<IntentType, double> ambitionBias,
+            AmbitionBias ambitionBias,
             Func<Guid, int> opinionOf,
             Func<Guid, Guid> factionOf,
             PlannerConfig config)

--- a/Infrastructure/Social/IntentPlanner.cs
+++ b/Infrastructure/Social/IntentPlanner.cs
@@ -214,79 +214,82 @@ namespace SkyHorizont.Infrastructure.Social
             return security;
         }
 
-        private IReadOnlyDictionary<IntentType, double> GetAmbitionBias(CharacterAmbition ambition)
+        private AmbitionBias GetAmbitionBias(CharacterAmbition ambition)
         {
-            var bias = Enum.GetValues<IntentType>().ToDictionary(t => t, _ => 1.0);
+            var bias = new AmbitionBias();
 
-            switch (ambition)
+            return ambition switch
             {
-                case CharacterAmbition.GainPower:
-                    bias[IntentType.Court] = 0.8;
-                    bias[IntentType.VisitFamily] = 0.7;
-                    bias[IntentType.Spy] = 1.2;
-                    bias[IntentType.Bribe] = 1.1;
-                    bias[IntentType.Recruit] = 1.2;
-                    bias[IntentType.Defect] = 1.3;
-                    bias[IntentType.Negotiate] = 1.0;
-                    bias[IntentType.Quarrel] = 1.0;
-                    bias[IntentType.Assassinate] = 1.3;
-                    bias[IntentType.TorturePrisoner] = 1.0;
-                    bias[IntentType.RapePrisoner] = 0.9;
-                    bias[IntentType.TravelToPlanet] = 0.8;
-                    bias[IntentType.BecomePirate] = 0.9;
-                    bias[IntentType.RaidConvoy] = 0.8;
-                    break;
-                case CharacterAmbition.BuildWealth:
-                    bias[IntentType.Court] = 0.9;
-                    bias[IntentType.VisitFamily] = 0.8;
-                    bias[IntentType.Spy] = 1.1;
-                    bias[IntentType.Bribe] = 1.3;
-                    bias[IntentType.Recruit] = 1.1;
-                    bias[IntentType.Defect] = 0.8;
-                    bias[IntentType.Negotiate] = 1.2;
-                    bias[IntentType.Quarrel] = 0.7;
-                    bias[IntentType.Assassinate] = 0.8;
-                    bias[IntentType.TorturePrisoner] = 0.7;
-                    bias[IntentType.RapePrisoner] = 0.6;
-                    bias[IntentType.TravelToPlanet] = 1.0;
-                    bias[IntentType.BecomePirate] = 1.2;
-                    bias[IntentType.RaidConvoy] = 1.3;
-                    break;
-                case CharacterAmbition.EnsureFamilyLegacy:
-                    bias[IntentType.Court] = 1.2;
-                    bias[IntentType.VisitFamily] = 1.3;
-                    bias[IntentType.Spy] = 0.8;
-                    bias[IntentType.Bribe] = 0.9;
-                    bias[IntentType.Recruit] = 0.9;
-                    bias[IntentType.Defect] = 0.7;
-                    bias[IntentType.Negotiate] = 0.9;
-                    bias[IntentType.Quarrel] = 0.8;
-                    bias[IntentType.Assassinate] = 0.7;
-                    bias[IntentType.TorturePrisoner] = 0.6;
-                    bias[IntentType.RapePrisoner] = 0.5;
-                    bias[IntentType.TravelToPlanet] = 1.1;
-                    bias[IntentType.BecomePirate] = 0.7;
-                    bias[IntentType.RaidConvoy] = 0.6;
-                    break;
-                case CharacterAmbition.SeekAdventure:
-                    bias[IntentType.Court] = 0.9;
-                    bias[IntentType.VisitFamily] = 0.8;
-                    bias[IntentType.Spy] = 1.2;
-                    bias[IntentType.Bribe] = 0.9;
-                    bias[IntentType.Recruit] = 0.9;
-                    bias[IntentType.Defect] = 1.0;
-                    bias[IntentType.Negotiate] = 0.9;
-                    bias[IntentType.Quarrel] = 1.0;
-                    bias[IntentType.Assassinate] = 1.0;
-                    bias[IntentType.TorturePrisoner] = 0.8;
-                    bias[IntentType.RapePrisoner] = 0.7;
-                    bias[IntentType.TravelToPlanet] = 1.3;
-                    bias[IntentType.BecomePirate] = 1.2;
-                    bias[IntentType.RaidConvoy] = 1.2;
-                    break;
-            }
-
-            return bias;
+                CharacterAmbition.GainPower => bias with
+                {
+                    Court = 0.8,
+                    VisitFamily = 0.7,
+                    Spy = 1.2,
+                    Bribe = 1.1,
+                    Recruit = 1.2,
+                    Defect = 1.3,
+                    Negotiate = 1.0,
+                    Quarrel = 1.0,
+                    Assassinate = 1.3,
+                    TorturePrisoner = 1.0,
+                    RapePrisoner = 0.9,
+                    TravelToPlanet = 0.8,
+                    BecomePirate = 0.9,
+                    RaidConvoy = 0.8
+                },
+                CharacterAmbition.BuildWealth => bias with
+                {
+                    Court = 0.9,
+                    VisitFamily = 0.8,
+                    Spy = 1.1,
+                    Bribe = 1.3,
+                    Recruit = 1.1,
+                    Defect = 0.8,
+                    Negotiate = 1.2,
+                    Quarrel = 0.7,
+                    Assassinate = 0.8,
+                    TorturePrisoner = 0.7,
+                    RapePrisoner = 0.6,
+                    TravelToPlanet = 1.0,
+                    BecomePirate = 1.2,
+                    RaidConvoy = 1.3
+                },
+                CharacterAmbition.EnsureFamilyLegacy => bias with
+                {
+                    Court = 1.2,
+                    VisitFamily = 1.3,
+                    Spy = 0.8,
+                    Bribe = 0.9,
+                    Recruit = 0.9,
+                    Defect = 0.7,
+                    Negotiate = 0.9,
+                    Quarrel = 0.8,
+                    Assassinate = 0.7,
+                    TorturePrisoner = 0.6,
+                    RapePrisoner = 0.5,
+                    TravelToPlanet = 1.1,
+                    BecomePirate = 0.7,
+                    RaidConvoy = 0.6
+                },
+                CharacterAmbition.SeekAdventure => bias with
+                {
+                    Court = 0.9,
+                    VisitFamily = 0.8,
+                    Spy = 1.2,
+                    Bribe = 0.9,
+                    Recruit = 0.9,
+                    Defect = 1.0,
+                    Negotiate = 0.9,
+                    Quarrel = 1.0,
+                    Assassinate = 1.0,
+                    TorturePrisoner = 0.8,
+                    RapePrisoner = 0.7,
+                    TravelToPlanet = 1.3,
+                    BecomePirate = 1.2,
+                    RaidConvoy = 1.2
+                },
+                _ => bias
+            };
         }
 
         private List<ScoredIntent> ResolveConflictsTargetAware(Character actor, List<ScoredIntent> candidates, int take, Func<Guid, Guid> fac)

--- a/Infrastructure/Social/IntentRules/AssassinateIntentRule.cs
+++ b/Infrastructure/Social/IntentRules/AssassinateIntentRule.cs
@@ -22,7 +22,7 @@ namespace SkyHorizont.Infrastructure.Social.IntentRules
             if (target == null)
                 yield break;
 
-            var score = ScoreAssassinate(ctx.Actor, target, ctx.ActorFactionId, ctx.FactionStatus, ctx.FactionOf, ctx.OpinionOf, ctx.Config) * ctx.AmbitionBias[IntentType.Assassinate];
+            var score = ScoreAssassinate(ctx.Actor, target, ctx.ActorFactionId, ctx.FactionStatus, ctx.FactionOf, ctx.OpinionOf, ctx.Config) * ctx.AmbitionBias.Assassinate;
             if (score > 0)
                 yield return new ScoredIntent(IntentType.Assassinate, score, target.Id, null, null);
         }

--- a/Infrastructure/Social/IntentRules/BecomePirateIntentRule.cs
+++ b/Infrastructure/Social/IntentRules/BecomePirateIntentRule.cs
@@ -23,7 +23,7 @@ namespace SkyHorizont.Infrastructure.Social.IntentRules
             if (_piracy.IsPirateFaction(ctx.ActorFactionId))
                 yield break;
 
-            var score = ScoreBecomePirate(ctx.Actor, ctx.ActorFactionId, ctx.ActorLeaderId, ctx.SystemSecurity, ctx.OpinionOf, ctx.FactionStatus, ctx.Config) * ctx.AmbitionBias[IntentType.BecomePirate];
+            var score = ScoreBecomePirate(ctx.Actor, ctx.ActorFactionId, ctx.ActorLeaderId, ctx.SystemSecurity, ctx.OpinionOf, ctx.FactionStatus, ctx.Config) * ctx.AmbitionBias.BecomePirate;
             if (score > 0)
                 yield return new ScoredIntent(IntentType.BecomePirate, score, null, null, null);
         }

--- a/Infrastructure/Social/IntentRules/BribeIntentRule.cs
+++ b/Infrastructure/Social/IntentRules/BribeIntentRule.cs
@@ -22,7 +22,7 @@ namespace SkyHorizont.Infrastructure.Social.IntentRules
             if (target == null)
                 yield break;
 
-            var score = ScoreBribe(ctx.Actor, target, ctx.ActorFactionId, ctx.FactionStatus, ctx.FactionOf, ctx.Config) * ctx.AmbitionBias[IntentType.Bribe];
+            var score = ScoreBribe(ctx.Actor, target, ctx.ActorFactionId, ctx.FactionStatus, ctx.FactionOf, ctx.Config) * ctx.AmbitionBias.Bribe;
             if (score > 0)
                 yield return new ScoredIntent(IntentType.Bribe, score, target.Id, null, null);
         }

--- a/Infrastructure/Social/IntentRules/ClaimPlanetSeatIntentRule.cs
+++ b/Infrastructure/Social/IntentRules/ClaimPlanetSeatIntentRule.cs
@@ -27,7 +27,7 @@ namespace SkyHorizont.Infrastructure.Social.IntentRules
             if (planet.IsSeatOf(ctx.ActorFactionId))
                 yield break;
 
-            var score = ScoreClaimSeat(ctx.Actor, planet, ctx.Config) * ctx.AmbitionBias.ClaimPlanet;
+            var score = ScoreClaimSeat(ctx.Actor, planet, ctx.Config) * ctx.AmbitionBias.ClaimPlanetSeat;
             if (score > 0)
                 yield return new ScoredIntent(IntentType.ClaimPlanetSeat, score, null, null, planet.Id);
         }

--- a/Infrastructure/Social/IntentRules/CourtshipIntentRule.cs
+++ b/Infrastructure/Social/IntentRules/CourtshipIntentRule.cs
@@ -21,7 +21,7 @@ namespace SkyHorizont.Infrastructure.Social.IntentRules
             if (target == null)
                 yield break;
 
-            var score = ScoreCourtship(ctx.Actor, target, ctx.FactionStatus, ctx.OpinionOf, ctx.Config) * ctx.AmbitionBias[IntentType.Court];
+            var score = ScoreCourtship(ctx.Actor, target, ctx.FactionStatus, ctx.OpinionOf, ctx.Config) * ctx.AmbitionBias.Court;
             if (score > 0)
                 yield return new ScoredIntent(IntentType.Court, score, target.Id, null, null);
         }

--- a/Infrastructure/Social/IntentRules/DefectIntentRule.cs
+++ b/Infrastructure/Social/IntentRules/DefectIntentRule.cs
@@ -25,7 +25,7 @@ namespace SkyHorizont.Infrastructure.Social.IntentRules
             if (targetFaction == Guid.Empty)
                 yield break;
 
-            var score = ScoreDefect(ctx.Actor, ctx.ActorLeaderId.Value, ctx.ActorFactionId, targetFaction, ctx.FactionStatus, ctx.OpinionOf, ctx.Config) * ctx.AmbitionBias[IntentType.Defect];
+            var score = ScoreDefect(ctx.Actor, ctx.ActorLeaderId.Value, ctx.ActorFactionId, targetFaction, ctx.FactionStatus, ctx.OpinionOf, ctx.Config) * ctx.AmbitionBias.Defect;
             if (score > 0)
                 yield return new ScoredIntent(IntentType.Defect, score, null, targetFaction, null);
         }

--- a/Infrastructure/Social/IntentRules/NegotiateIntentRule.cs
+++ b/Infrastructure/Social/IntentRules/NegotiateIntentRule.cs
@@ -22,7 +22,7 @@ namespace SkyHorizont.Infrastructure.Social.IntentRules
             if (targetFaction == Guid.Empty)
                 yield break;
 
-            var score = ScoreNegotiate(ctx.Actor, ctx.ActorFactionId, targetFaction, ctx.FactionStatus, ctx.Config) * ctx.AmbitionBias[IntentType.Negotiate];
+            var score = ScoreNegotiate(ctx.Actor, ctx.ActorFactionId, targetFaction, ctx.FactionStatus, ctx.Config) * ctx.AmbitionBias.Negotiate;
             if (score > 0)
                 yield return new ScoredIntent(IntentType.Negotiate, score, null, targetFaction, null);
         }

--- a/Infrastructure/Social/IntentRules/QuarrelIntentRule.cs
+++ b/Infrastructure/Social/IntentRules/QuarrelIntentRule.cs
@@ -20,7 +20,7 @@ namespace SkyHorizont.Infrastructure.Social.IntentRules
             if (target == null)
                 yield break;
 
-            var score = ScoreQuarrel(ctx.Actor, target, ctx.FactionStatus, ctx.OpinionOf, ctx.Config) * ctx.AmbitionBias[IntentType.Quarrel];
+            var score = ScoreQuarrel(ctx.Actor, target, ctx.FactionStatus, ctx.OpinionOf, ctx.Config) * ctx.AmbitionBias.Quarrel;
             if (score > 0)
                 yield return new ScoredIntent(IntentType.Quarrel, score, target.Id, null, null);
         }

--- a/Infrastructure/Social/IntentRules/RaidConvoyIntentRule.cs
+++ b/Infrastructure/Social/IntentRules/RaidConvoyIntentRule.cs
@@ -32,7 +32,7 @@ namespace SkyHorizont.Infrastructure.Social.IntentRules
                 yield break;
 
             var security = GetSystemSecurity(targetSystem.Value);
-            var score = ScoreRaidConvoy(ctx.Actor, targetSystem.Value, security, ctx.Config) * ctx.AmbitionBias[IntentType.RaidConvoy];
+            var score = ScoreRaidConvoy(ctx.Actor, targetSystem.Value, security, ctx.Config) * ctx.AmbitionBias.RaidConvoy;
             if (score > 0)
                 yield return new ScoredIntent(IntentType.RaidConvoy, score, null, targetSystem.Value, null);
         }

--- a/Infrastructure/Social/IntentRules/RapePrisonerIntentRule.cs
+++ b/Infrastructure/Social/IntentRules/RapePrisonerIntentRule.cs
@@ -22,7 +22,7 @@ namespace SkyHorizont.Infrastructure.Social.IntentRules
             if (target == null)
                 yield break;
 
-            var score = ScoreRape(ctx.Actor, target, ctx.ActorFactionId, ctx.FactionStatus, ctx.FactionOf, ctx.OpinionOf, ctx.Config) * ctx.AmbitionBias[IntentType.RapePrisoner];
+            var score = ScoreRape(ctx.Actor, target, ctx.ActorFactionId, ctx.FactionStatus, ctx.FactionOf, ctx.OpinionOf, ctx.Config) * ctx.AmbitionBias.RapePrisoner;
             if (score > 0)
                 yield return new ScoredIntent(IntentType.RapePrisoner, score, target.Id, null, null);
         }

--- a/Infrastructure/Social/IntentRules/RecruitIntentRule.cs
+++ b/Infrastructure/Social/IntentRules/RecruitIntentRule.cs
@@ -31,7 +31,7 @@ namespace SkyHorizont.Infrastructure.Social.IntentRules
             if (target == null)
                 yield break;
 
-            var score = ScoreRecruit(ctx.Actor, target, ctx.ActorFactionId, ctx.FactionStatus, ctx.FactionOf, ctx.OpinionOf, ctx.Config) * ctx.AmbitionBias[IntentType.Recruit];
+            var score = ScoreRecruit(ctx.Actor, target, ctx.ActorFactionId, ctx.FactionStatus, ctx.FactionOf, ctx.OpinionOf, ctx.Config) * ctx.AmbitionBias.Recruit;
             if (score > 0)
                 yield return new ScoredIntent(IntentType.Recruit, score, target.Id, null, null);
         }

--- a/Infrastructure/Social/IntentRules/SpyIntentRule.cs
+++ b/Infrastructure/Social/IntentRules/SpyIntentRule.cs
@@ -18,7 +18,7 @@ namespace SkyHorizont.Infrastructure.Social.IntentRules
 
         public IEnumerable<ScoredIntent> Generate(IntentContext ctx)
         {
-            var scoreBase = ScoreSpy(ctx.Actor, ctx.FactionStatus, ctx.Config) * ctx.AmbitionBias[IntentType.Spy];
+            var scoreBase = ScoreSpy(ctx.Actor, ctx.FactionStatus, ctx.Config) * ctx.AmbitionBias.Spy;
             if (scoreBase <= 0)
                 yield break;
 

--- a/Infrastructure/Social/IntentRules/TorturePrisonerIntentRule.cs
+++ b/Infrastructure/Social/IntentRules/TorturePrisonerIntentRule.cs
@@ -22,7 +22,7 @@ namespace SkyHorizont.Infrastructure.Social.IntentRules
             if (target == null)
                 yield break;
 
-            var score = ScoreTorture(ctx.Actor, target, ctx.ActorFactionId, ctx.FactionStatus, ctx.FactionOf, ctx.OpinionOf, ctx.Config) * ctx.AmbitionBias[IntentType.TorturePrisoner];
+            var score = ScoreTorture(ctx.Actor, target, ctx.ActorFactionId, ctx.FactionStatus, ctx.FactionOf, ctx.OpinionOf, ctx.Config) * ctx.AmbitionBias.TorturePrisoner;
             if (score > 0)
                 yield return new ScoredIntent(IntentType.TorturePrisoner, score, target.Id, null, null);
         }

--- a/Infrastructure/Social/IntentRules/TravelIntentRule.cs
+++ b/Infrastructure/Social/IntentRules/TravelIntentRule.cs
@@ -26,7 +26,7 @@ namespace SkyHorizont.Infrastructure.Social.IntentRules
             if (!dest.HasValue)
                 yield break;
 
-            var score = ScoreTravel(ctx.Actor, dest.Value, ctx.FactionStatus, ctx.SystemSecurity, ctx.Config) * ctx.AmbitionBias[IntentType.TravelToPlanet];
+            var score = ScoreTravel(ctx.Actor, dest.Value, ctx.FactionStatus, ctx.SystemSecurity, ctx.Config) * ctx.AmbitionBias.TravelToPlanet;
             if (score > 0)
                 yield return new ScoredIntent(IntentType.TravelToPlanet, score, null, null, dest.Value);
         }

--- a/Infrastructure/Social/IntentRules/VisitFamilyIntentRule.cs
+++ b/Infrastructure/Social/IntentRules/VisitFamilyIntentRule.cs
@@ -20,7 +20,7 @@ namespace SkyHorizont.Infrastructure.Social.IntentRules
             if (!target.HasValue)
                 yield break;
 
-            var score = ScoreVisitFamily(ctx.Actor, target.Value, ctx.FactionStatus, ctx.OpinionOf, ctx.Config) * ctx.AmbitionBias[IntentType.VisitFamily];
+            var score = ScoreVisitFamily(ctx.Actor, target.Value, ctx.FactionStatus, ctx.OpinionOf, ctx.Config) * ctx.AmbitionBias.VisitFamily;
             if (score > 0)
                 yield return new ScoredIntent(IntentType.VisitFamily, score, target.Value, null, null);
         }

--- a/Tests/Infrastructure/AmbitionBiasTests.cs
+++ b/Tests/Infrastructure/AmbitionBiasTests.cs
@@ -1,0 +1,136 @@
+using System.Reflection;
+using FluentAssertions;
+using Moq;
+using SkyHorizont.Domain.Entity;
+using SkyHorizont.Domain.Social;
+using SkyHorizont.Domain.Factions;
+using SkyHorizont.Domain.Services;
+using SkyHorizont.Domain.Galaxy.Planet;
+using SkyHorizont.Domain.Fleets;
+using SkyHorizont.Domain.Travel;
+using SkyHorizont.Infrastructure.Social;
+using Xunit;
+
+namespace SkyHorizont.Tests.Infrastructure;
+
+public class AmbitionBiasTests
+{
+    private static AmbitionBias Invoke(CharacterAmbition ambition)
+    {
+        var planner = new IntentPlanner(
+            Mock.Of<ICharacterRepository>(),
+            Mock.Of<IOpinionRepository>(),
+            Mock.Of<IFactionService>(),
+            Mock.Of<IRandomService>(),
+            Mock.Of<IPlanetRepository>(),
+            Mock.Of<IFleetRepository>(),
+            Mock.Of<IPiracyService>(),
+            Enumerable.Empty<IIntentRule>());
+
+        var method = typeof(IntentPlanner).GetMethod("GetAmbitionBias", BindingFlags.NonPublic | BindingFlags.Instance)!;
+        return (AmbitionBias)method.Invoke(planner, new object[] { ambition })!;
+    }
+
+    public static IEnumerable<object[]> BiasData()
+    {
+        yield return new object[]
+        {
+            CharacterAmbition.GainPower,
+            new Dictionary<IntentType, double>
+            {
+                { IntentType.Court, 0.8 },
+                { IntentType.VisitFamily, 0.7 },
+                { IntentType.Spy, 1.2 },
+                { IntentType.Bribe, 1.1 },
+                { IntentType.Recruit, 1.2 },
+                { IntentType.Defect, 1.3 },
+                { IntentType.Negotiate, 1.0 },
+                { IntentType.Quarrel, 1.0 },
+                { IntentType.Assassinate, 1.3 },
+                { IntentType.TorturePrisoner, 1.0 },
+                { IntentType.RapePrisoner, 0.9 },
+                { IntentType.TravelToPlanet, 0.8 },
+                { IntentType.BecomePirate, 0.9 },
+                { IntentType.RaidConvoy, 0.8 }
+            }
+        };
+
+        yield return new object[]
+        {
+            CharacterAmbition.BuildWealth,
+            new Dictionary<IntentType, double>
+            {
+                { IntentType.Court, 0.9 },
+                { IntentType.VisitFamily, 0.8 },
+                { IntentType.Spy, 1.1 },
+                { IntentType.Bribe, 1.3 },
+                { IntentType.Recruit, 1.1 },
+                { IntentType.Defect, 0.8 },
+                { IntentType.Negotiate, 1.2 },
+                { IntentType.Quarrel, 0.7 },
+                { IntentType.Assassinate, 0.8 },
+                { IntentType.TorturePrisoner, 0.7 },
+                { IntentType.RapePrisoner, 0.6 },
+                { IntentType.TravelToPlanet, 1.0 },
+                { IntentType.BecomePirate, 1.2 },
+                { IntentType.RaidConvoy, 1.3 }
+            }
+        };
+
+        yield return new object[]
+        {
+            CharacterAmbition.EnsureFamilyLegacy,
+            new Dictionary<IntentType, double>
+            {
+                { IntentType.Court, 1.2 },
+                { IntentType.VisitFamily, 1.3 },
+                { IntentType.Spy, 0.8 },
+                { IntentType.Bribe, 0.9 },
+                { IntentType.Recruit, 0.9 },
+                { IntentType.Defect, 0.7 },
+                { IntentType.Negotiate, 0.9 },
+                { IntentType.Quarrel, 0.8 },
+                { IntentType.Assassinate, 0.7 },
+                { IntentType.TorturePrisoner, 0.6 },
+                { IntentType.RapePrisoner, 0.5 },
+                { IntentType.TravelToPlanet, 1.1 },
+                { IntentType.BecomePirate, 0.7 },
+                { IntentType.RaidConvoy, 0.6 }
+            }
+        };
+
+        yield return new object[]
+        {
+            CharacterAmbition.SeekAdventure,
+            new Dictionary<IntentType, double>
+            {
+                { IntentType.Court, 0.9 },
+                { IntentType.VisitFamily, 0.8 },
+                { IntentType.Spy, 1.2 },
+                { IntentType.Bribe, 0.9 },
+                { IntentType.Recruit, 0.9 },
+                { IntentType.Defect, 1.0 },
+                { IntentType.Negotiate, 0.9 },
+                { IntentType.Quarrel, 1.0 },
+                { IntentType.Assassinate, 1.0 },
+                { IntentType.TorturePrisoner, 0.8 },
+                { IntentType.RapePrisoner, 0.7 },
+                { IntentType.TravelToPlanet, 1.3 },
+                { IntentType.BecomePirate, 1.2 },
+                { IntentType.RaidConvoy, 1.2 }
+            }
+        };
+    }
+
+    [Theory]
+    [MemberData(nameof(BiasData))]
+    public void GetAmbitionBias_maps_values(CharacterAmbition ambition, Dictionary<IntentType, double> expected)
+    {
+        var bias = Invoke(ambition);
+        foreach (var intent in Enum.GetValues<IntentType>())
+        {
+            var expectedValue = expected.TryGetValue(intent, out var v) ? v : 1.0;
+            bias[intent].Should().Be(expectedValue);
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- introduce `AmbitionBias` record with named properties for each intent
- update intent planner and rules to use `AmbitionBias` instead of dictionary lookups
- cover ambition bias mappings with unit tests

## Testing
- `dotnet test`


------
https://chatgpt.com/codex/tasks/task_e_68ac2c0b2a988321a903cfdb2e4507f6