### PR TITLE
Add BuildFleet intent and fleet construction workflow

### DIFF
--- a/Domain/Social/AmbitionBias.cs
+++ b/Domain/Social/AmbitionBias.cs
@@ -22,6 +22,7 @@ public sealed record AmbitionBias
     public double FoundPirateClan { get; init; } = 1.0;
     public double ExpelFromHouse { get; init; } = 1.0;
     public double ClaimPlanetSeat { get; init; } = 1.0;
+    public double BuildFleet { get; init; } = 1.0;
 
     public double this[IntentType intent] => intent switch
     {
@@ -45,6 +46,7 @@ public sealed record AmbitionBias
         IntentType.FoundPirateClan => FoundPirateClan,
         IntentType.ExpelFromHouse => ExpelFromHouse,
         IntentType.ClaimPlanetSeat => ClaimPlanetSeat,
+        IntentType.BuildFleet => BuildFleet,
         _ => 1.0
     };
 }

--- a/Domain/Social/IntentModels.cs
+++ b/Domain/Social/IntentModels.cs
@@ -10,7 +10,8 @@ namespace SkyHorizont.Domain.Social
         FoundHouse,
         FoundPirateClan,
         ExpelFromHouse,
-        ClaimPlanetSeat
+        ClaimPlanetSeat,
+        BuildFleet
     }
 
     /// <summary> Planned monthly action for one actor. </summary>

--- a/Domain/Social/SocialEvent.cs
+++ b/Domain/Social/SocialEvent.cs
@@ -17,6 +17,7 @@ namespace SkyHorizont.Domain.Social
         TravelBooked,
         PirateDefection,
         RaidPlanned,
+        BuildFleet,
         FoundGreatHouse,
         FoundPirateClan,
         ClaimPlanet,

--- a/Infrastructure/Social/IntentPlanner.cs
+++ b/Infrastructure/Social/IntentPlanner.cs
@@ -235,7 +235,8 @@ namespace SkyHorizont.Infrastructure.Social
                     RapePrisoner = 0.9,
                     TravelToPlanet = 0.8,
                     BecomePirate = 0.9,
-                    RaidConvoy = 0.8
+                    RaidConvoy = 0.8,
+                    BuildFleet = 1.3
                 },
                 CharacterAmbition.BuildWealth => bias with
                 {
@@ -252,7 +253,8 @@ namespace SkyHorizont.Infrastructure.Social
                     RapePrisoner = 0.6,
                     TravelToPlanet = 1.0,
                     BecomePirate = 1.2,
-                    RaidConvoy = 1.3
+                    RaidConvoy = 1.3,
+                    BuildFleet = 0.8
                 },
                 CharacterAmbition.EnsureFamilyLegacy => bias with
                 {
@@ -269,7 +271,8 @@ namespace SkyHorizont.Infrastructure.Social
                     RapePrisoner = 0.5,
                     TravelToPlanet = 1.1,
                     BecomePirate = 0.7,
-                    RaidConvoy = 0.6
+                    RaidConvoy = 0.6,
+                    BuildFleet = 0.7
                 },
                 CharacterAmbition.SeekAdventure => bias with
                 {
@@ -286,7 +289,8 @@ namespace SkyHorizont.Infrastructure.Social
                     RapePrisoner = 0.7,
                     TravelToPlanet = 1.3,
                     BecomePirate = 1.2,
-                    RaidConvoy = 1.2
+                    RaidConvoy = 1.2,
+                    BuildFleet = 1.2
                 },
                 _ => bias
             };
@@ -298,6 +302,7 @@ namespace SkyHorizont.Infrastructure.Social
             var chosenCharTargets = new HashSet<Guid>();
             var chosenFactionTargets = new HashSet<Guid>();
             var chosenPlanetTargets = new HashSet<Guid>();
+            bool buildFleetChosen = false;
 
             foreach (var si in candidates)
             {
@@ -336,12 +341,19 @@ namespace SkyHorizont.Infrastructure.Social
                         conflict = true;
                 }
 
+                if (si.Type == IntentType.BuildFleet)
+                {
+                    if (buildFleetChosen)
+                        conflict = true;
+                }
+
                 if (!conflict)
                 {
                     kept.Add(si);
                     if (tc.HasValue) chosenCharTargets.Add(tc.Value);
                     if (tf.HasValue) chosenFactionTargets.Add(tf.Value);
                     if (tp.HasValue) chosenPlanetTargets.Add(tp.Value);
+                    if (si.Type == IntentType.BuildFleet) buildFleetChosen = true;
                 }
             }
 

--- a/Infrastructure/Social/IntentRules/BuildFleetIntentRule.cs
+++ b/Infrastructure/Social/IntentRules/BuildFleetIntentRule.cs
@@ -1,0 +1,33 @@
+using System.Linq;
+using SkyHorizont.Domain.Fleets;
+using SkyHorizont.Domain.Social;
+
+namespace SkyHorizont.Infrastructure.Social.IntentRules
+{
+    public sealed class BuildFleetIntentRule : IIntentRule
+    {
+        private readonly IFleetRepository _fleets;
+
+        public BuildFleetIntentRule(IFleetRepository fleets)
+        {
+            _fleets = fleets;
+        }
+
+        public IEnumerable<ScoredIntent> Generate(IntentContext ctx)
+        {
+            var factionFleets = _fleets.GetFleetsForFaction(ctx.ActorFactionId).ToList();
+            double strength = factionFleets.Sum(f => f.CalculateStrength().MilitaryPower);
+
+            double score = 0;
+            if (strength < 100) score += 50;
+            else if (strength < 300) score += 20;
+
+            if (ctx.FactionStatus.IsAtWar) score += 40;
+
+            score *= ctx.AmbitionBias.BuildFleet;
+
+            if (score > 0)
+                yield return new ScoredIntent(IntentType.BuildFleet, score, null, null, null);
+        }
+    }
+}

--- a/Tests/Common/LifeCycleTest.cs
+++ b/Tests/Common/LifeCycleTest.cs
@@ -51,6 +51,7 @@ namespace SkyHorizont.Tests.Common
             var travel = new TravelService(planets, fleets, rng, travels, piracy, clock);
             var fund = new CharacterFundsService(funds);
             var tax = new FactionTaxService(factionFunds, funds, planets, eco, faction, characters, clock);
+            var factionFundsSvc = new FundsService(factionFunds);
             var moral = new MoraleService(characters);
             var battle = new BattleOutcomeService(fund, factionFunds, tax, characters, moral);
             var affection = new AffectionService(characters, planets, fleets, affections);
@@ -65,7 +66,7 @@ namespace SkyHorizont.Tests.Common
             };
             var planner = new IntentPlanner(characters, opinions, faction, rng, planets, fleets, piracy, rules);
             var diplomacy = new DiplomacyService(diplomacies, faction, clock, opinions);
-            var resolver = new InteractionResolver(characters, opinions, faction, secrets, rng, diplomacy, travel, piracy, planets, fleets, events, battle, intimacy, merit);
+            var resolver = new InteractionResolver(characters, opinions, faction, secrets, rng, diplomacy, travel, piracy, planets, fleets, factionFundsSvc, events, battle, intimacy, merit);
 
             var lifecycle = new CharacterLifecycleService(
                 characters, lineage, clock, rng, mortality, nameGen,

--- a/Tests/Infrastructure/AmbitionBiasTests.cs
+++ b/Tests/Infrastructure/AmbitionBiasTests.cs
@@ -37,23 +37,24 @@ public class AmbitionBiasTests
         {
             CharacterAmbition.GainPower,
             new Dictionary<IntentType, double>
-            {
-                { IntentType.Court, 0.8 },
-                { IntentType.VisitFamily, 0.7 },
-                { IntentType.Spy, 1.2 },
-                { IntentType.Bribe, 1.1 },
-                { IntentType.Recruit, 1.2 },
-                { IntentType.Defect, 1.3 },
-                { IntentType.Negotiate, 1.0 },
-                { IntentType.Quarrel, 1.0 },
-                { IntentType.Assassinate, 1.3 },
-                { IntentType.TorturePrisoner, 1.0 },
-                { IntentType.RapePrisoner, 0.9 },
-                { IntentType.TravelToPlanet, 0.8 },
-                { IntentType.BecomePirate, 0.9 },
-                { IntentType.RaidConvoy, 0.8 }
-            }
-        };
+                {
+                    { IntentType.Court, 0.8 },
+                    { IntentType.VisitFamily, 0.7 },
+                    { IntentType.Spy, 1.2 },
+                    { IntentType.Bribe, 1.1 },
+                    { IntentType.Recruit, 1.2 },
+                    { IntentType.Defect, 1.3 },
+                    { IntentType.Negotiate, 1.0 },
+                    { IntentType.Quarrel, 1.0 },
+                    { IntentType.Assassinate, 1.3 },
+                    { IntentType.TorturePrisoner, 1.0 },
+                    { IntentType.RapePrisoner, 0.9 },
+                    { IntentType.TravelToPlanet, 0.8 },
+                    { IntentType.BecomePirate, 0.9 },
+                    { IntentType.RaidConvoy, 0.8 },
+                    { IntentType.BuildFleet, 1.3 }
+                }
+            };
 
         yield return new object[]
         {
@@ -70,12 +71,13 @@ public class AmbitionBiasTests
                 { IntentType.Quarrel, 0.7 },
                 { IntentType.Assassinate, 0.8 },
                 { IntentType.TorturePrisoner, 0.7 },
-                { IntentType.RapePrisoner, 0.6 },
-                { IntentType.TravelToPlanet, 1.0 },
-                { IntentType.BecomePirate, 1.2 },
-                { IntentType.RaidConvoy, 1.3 }
-            }
-        };
+                    { IntentType.RapePrisoner, 0.6 },
+                    { IntentType.TravelToPlanet, 1.0 },
+                    { IntentType.BecomePirate, 1.2 },
+                    { IntentType.RaidConvoy, 1.3 },
+                    { IntentType.BuildFleet, 0.8 }
+                }
+            };
 
         yield return new object[]
         {
@@ -92,12 +94,13 @@ public class AmbitionBiasTests
                 { IntentType.Quarrel, 0.8 },
                 { IntentType.Assassinate, 0.7 },
                 { IntentType.TorturePrisoner, 0.6 },
-                { IntentType.RapePrisoner, 0.5 },
-                { IntentType.TravelToPlanet, 1.1 },
-                { IntentType.BecomePirate, 0.7 },
-                { IntentType.RaidConvoy, 0.6 }
-            }
-        };
+                    { IntentType.RapePrisoner, 0.5 },
+                    { IntentType.TravelToPlanet, 1.1 },
+                    { IntentType.BecomePirate, 0.7 },
+                    { IntentType.RaidConvoy, 0.6 },
+                    { IntentType.BuildFleet, 0.7 }
+                }
+            };
 
         yield return new object[]
         {
@@ -114,12 +117,13 @@ public class AmbitionBiasTests
                 { IntentType.Quarrel, 1.0 },
                 { IntentType.Assassinate, 1.0 },
                 { IntentType.TorturePrisoner, 0.8 },
-                { IntentType.RapePrisoner, 0.7 },
-                { IntentType.TravelToPlanet, 1.3 },
-                { IntentType.BecomePirate, 1.2 },
-                { IntentType.RaidConvoy, 1.2 }
-            }
-        };
+                    { IntentType.RapePrisoner, 0.7 },
+                    { IntentType.TravelToPlanet, 1.3 },
+                    { IntentType.BecomePirate, 1.2 },
+                    { IntentType.RaidConvoy, 1.2 },
+                    { IntentType.BuildFleet, 1.2 }
+                }
+            };
     }
 
     [Theory]

--- a/Tests/Infrastructure/BuildFleetResolverTests.cs
+++ b/Tests/Infrastructure/BuildFleetResolverTests.cs
@@ -1,0 +1,103 @@
+using System;
+using System.Linq;
+using FluentAssertions;
+using Moq;
+using SkyHorizont.Domain.Entity;
+using SkyHorizont.Domain.Factions;
+using SkyHorizont.Domain.Fleets;
+using SkyHorizont.Domain.Galaxy.Planet;
+using SkyHorizont.Domain.Diplomacy;
+using SkyHorizont.Domain.Services;
+using SkyHorizont.Domain.Social;
+using SkyHorizont.Domain.Intrigue;
+using SkyHorizont.Domain.Travel;
+using SkyHorizont.Domain.Battle;
+using SkyHorizont.Infrastructure.Social;
+using Xunit;
+
+namespace SkyHorizont.Tests.Infrastructure;
+
+public class BuildFleetResolverTests
+{
+    private static Character NewActor()
+    {
+        return new Character(Guid.NewGuid(), "A", 30, 3000, 1, Sex.Male,
+            new Personality(50,50,50,50,50), new SkillSet(50,50,50,50));
+    }
+
+    private static InteractionResolver CreateResolver(Character actor, IFleetRepository fleetRepo, IFundsService funds, out Guid factionId)
+    {
+        var fid = Guid.NewGuid();
+        factionId = fid;
+
+        var chars = new Mock<ICharacterRepository>();
+        chars.Setup(c => c.GetById(actor.Id)).Returns(actor);
+
+        var factions = new Mock<IFactionService>();
+        factions.Setup(f => f.GetFactionIdForCharacter(actor.Id)).Returns(fid);
+        factions.Setup(f => f.GetAllRivalFactions(fid)).Returns(Array.Empty<Guid>());
+        factions.Setup(f => f.GetEconomicStrength(fid)).Returns(100);
+
+        var planets = new Mock<IPlanetRepository>();
+        planets.Setup(p => p.GetAll()).Returns(Array.Empty<Planet>());
+        planets.Setup(p => p.GetPlanetsControlledByFaction(fid)).Returns(Array.Empty<Planet>());
+
+        var opinions = Mock.Of<IOpinionRepository>();
+        var secrets = Mock.Of<ISecretsRepository>();
+        var rng = Mock.Of<IRandomService>();
+        var diplomacy = Mock.Of<IDiplomacyService>();
+        var travel = Mock.Of<ITravelService>();
+        var piracy = Mock.Of<IPiracyService>();
+        var events = Mock.Of<IEventBus>();
+        var battle = Mock.Of<IBattleOutcomeService>();
+        var intimacy = Mock.Of<IIntimacyLog>();
+        var merit = Mock.Of<IMeritPolicy>();
+
+        return new InteractionResolver(chars.Object, opinions, factions.Object, secrets, rng, diplomacy, travel, piracy, planets.Object, fleetRepo, funds, events, battle, intimacy, merit);
+    }
+
+    [Fact]
+    public void ResolveBuildFleet_creates_fleet_and_deducts_funds_when_affordable()
+    {
+        var actor = NewActor();
+        var fleetRepo = new Mock<IFleetRepository>();
+        Fleet? savedFleet = null;
+        fleetRepo.Setup(f => f.Save(It.IsAny<Fleet>())).Callback<Fleet>(f => savedFleet = f);
+
+        var funds = new Mock<IFundsService>();
+        funds.Setup(f => f.HasFunds(It.IsAny<Guid>(), 1000)).Returns(true);
+        funds.Setup(f => f.Deduct(It.IsAny<Guid>(), 1000));
+
+        var resolver = CreateResolver(actor, fleetRepo.Object, funds.Object, out var factionId);
+        var intent = new CharacterIntent(actor.Id, IntentType.BuildFleet);
+
+        var ev = resolver.Resolve(intent, 3000, 1).Single();
+
+        funds.Verify(f => f.Deduct(factionId, 1000), Times.Once);
+        fleetRepo.Verify(f => f.Save(It.IsAny<Fleet>()), Times.Once);
+        savedFleet.Should().NotBeNull();
+        savedFleet!.Ships.Should().NotBeEmpty();
+        ev.Success.Should().BeTrue();
+        ev.Type.Should().Be(SocialEventType.BuildFleet);
+    }
+
+    [Fact]
+    public void ResolveBuildFleet_fails_when_insufficient_funds()
+    {
+        var actor = NewActor();
+        var fleetRepo = new Mock<IFleetRepository>();
+
+        var funds = new Mock<IFundsService>();
+        funds.Setup(f => f.HasFunds(It.IsAny<Guid>(), 1000)).Returns(false);
+
+        var resolver = CreateResolver(actor, fleetRepo.Object, funds.Object, out var factionId);
+        var intent = new CharacterIntent(actor.Id, IntentType.BuildFleet);
+
+        var ev = resolver.Resolve(intent, 3000, 1).Single();
+
+        funds.Verify(f => f.Deduct(It.IsAny<Guid>(), It.IsAny<int>()), Times.Never);
+        fleetRepo.Verify(f => f.Save(It.IsAny<Fleet>()), Times.Never);
+        ev.Success.Should().BeFalse();
+        ev.Type.Should().Be(SocialEventType.BuildFleet);
+    }
+}

--- a/Web/ServiceCollectionExtensions.cs
+++ b/Web/ServiceCollectionExtensions.cs
@@ -109,6 +109,7 @@ namespace SkyHorizont.Infrastructure.Configuration
             services.AddScoped<IIntentRule, FoundPirateClanIntentRule>();
             services.AddScoped<IIntentRule, ExpelFromHouseIntentRule>();
             services.AddScoped<IIntentRule, ClaimPlanetSeatIntentRule>();
+            services.AddScoped<IIntentRule, BuildFleetIntentRule>();
             services.AddScoped<IIntentPlanner, IntentPlanner>();
             services.AddScoped<IInteractionResolver, InteractionResolver>();
 


### PR DESCRIPTION
## Summary
- append `BuildFleet` to `IntentType` and ambition bias mapping
- implement `BuildFleetIntentRule` and bias handling in `IntentPlanner`
- resolve BuildFleet actions by spending funds and spawning starter fleets
- cover fleet creation success and failure paths with tests

## Testing
- `dotnet test`


------
https://chatgpt.com/codex/tasks/task_e_68ac2f7c03a08321b323631782a28fac