### PR TITLE
Add BuildInfrastructure social intent with planning and resolution support

### DIFF
--- a/Domain/Social/AmbitionBias.cs
+++ b/Domain/Social/AmbitionBias.cs
@@ -22,6 +22,7 @@ public sealed record AmbitionBias
     public double FoundPirateClan { get; init; } = 1.0;
     public double ExpelFromHouse { get; init; } = 1.0;
     public double ClaimPlanetSeat { get; init; } = 1.0;
+    public double BuildInfrastructure { get; init; } = 1.0;
 
     public double this[IntentType intent] => intent switch
     {
@@ -45,6 +46,7 @@ public sealed record AmbitionBias
         IntentType.FoundPirateClan => FoundPirateClan,
         IntentType.ExpelFromHouse => ExpelFromHouse,
         IntentType.ClaimPlanetSeat => ClaimPlanetSeat,
+        IntentType.BuildInfrastructure => BuildInfrastructure,
         _ => 1.0
     };
 }

--- a/Domain/Social/IntentModels.cs
+++ b/Domain/Social/IntentModels.cs
@@ -10,7 +10,8 @@ namespace SkyHorizont.Domain.Social
         FoundHouse,
         FoundPirateClan,
         ExpelFromHouse,
-        ClaimPlanetSeat
+        ClaimPlanetSeat,
+        BuildInfrastructure
     }
 
     /// <summary> Planned monthly action for one actor. </summary>

--- a/Infrastructure/Social/IntentPlanner.cs
+++ b/Infrastructure/Social/IntentPlanner.cs
@@ -235,7 +235,8 @@ namespace SkyHorizont.Infrastructure.Social
                     RapePrisoner = 0.9,
                     TravelToPlanet = 0.8,
                     BecomePirate = 0.9,
-                    RaidConvoy = 0.8
+                    RaidConvoy = 0.8,
+                    BuildInfrastructure = 0.9
                 },
                 CharacterAmbition.BuildWealth => bias with
                 {
@@ -252,7 +253,8 @@ namespace SkyHorizont.Infrastructure.Social
                     RapePrisoner = 0.6,
                     TravelToPlanet = 1.0,
                     BecomePirate = 1.2,
-                    RaidConvoy = 1.3
+                    RaidConvoy = 1.3,
+                    BuildInfrastructure = 1.3
                 },
                 CharacterAmbition.EnsureFamilyLegacy => bias with
                 {
@@ -269,7 +271,8 @@ namespace SkyHorizont.Infrastructure.Social
                     RapePrisoner = 0.5,
                     TravelToPlanet = 1.1,
                     BecomePirate = 0.7,
-                    RaidConvoy = 0.6
+                    RaidConvoy = 0.6,
+                    BuildInfrastructure = 1.2
                 },
                 CharacterAmbition.SeekAdventure => bias with
                 {
@@ -286,7 +289,8 @@ namespace SkyHorizont.Infrastructure.Social
                     RapePrisoner = 0.7,
                     TravelToPlanet = 1.3,
                     BecomePirate = 1.2,
-                    RaidConvoy = 1.2
+                    RaidConvoy = 1.2,
+                    BuildInfrastructure = 0.8
                 },
                 _ => bias
             };
@@ -324,7 +328,8 @@ namespace SkyHorizont.Infrastructure.Social
                         conflict = true;
                 }
 
-                if (si.Type == IntentType.TravelToPlanet || si.Type == IntentType.ClaimPlanetSeat)
+                if (si.Type == IntentType.TravelToPlanet || si.Type == IntentType.ClaimPlanetSeat ||
+                    si.Type == IntentType.BuildInfrastructure)
                 {
                     if (tp.HasValue && chosenPlanetTargets.Contains(tp.Value))
                         conflict = true;

--- a/Infrastructure/Social/IntentRules/BuildInfrastructureIntentRule.cs
+++ b/Infrastructure/Social/IntentRules/BuildInfrastructureIntentRule.cs
@@ -1,0 +1,54 @@
+using SkyHorizont.Domain.Entity;
+using SkyHorizont.Domain.Galaxy.Planet;
+using SkyHorizont.Domain.Social;
+
+namespace SkyHorizont.Infrastructure.Social.IntentRules
+{
+    public sealed class BuildInfrastructureIntentRule : IIntentRule
+    {
+        private readonly IPlanetRepository _planets;
+
+        public BuildInfrastructureIntentRule(IPlanetRepository planets)
+        {
+            _planets = planets;
+        }
+
+        public IEnumerable<ScoredIntent> Generate(IntentContext ctx)
+        {
+            if (ctx.ActorFactionId == Guid.Empty)
+                yield break;
+
+            var planetId = GetCharacterPlanetId(ctx.Actor.Id);
+            if (!planetId.HasValue)
+                yield break;
+            var planet = _planets.GetById(planetId.Value);
+            if (planet == null || planet.FactionId != ctx.ActorFactionId)
+                yield break;
+
+            var score = ScoreBuildInfrastructure(ctx, planet) * ctx.AmbitionBias.BuildInfrastructure;
+            if (score > 0)
+                yield return new ScoredIntent(IntentType.BuildInfrastructure, score, null, null, planet.Id);
+        }
+
+        private Guid? GetCharacterPlanetId(Guid characterId)
+        {
+            foreach (var p in _planets.GetAll())
+                if (p.Citizens.Contains(characterId) || p.Prisoners.Contains(characterId))
+                    return p.Id;
+            return null;
+        }
+
+        private double ScoreBuildInfrastructure(IntentContext ctx, Planet planet)
+        {
+            double baseScore = 10.0;
+            if (ctx.FactionStatus.EconomyWeak)
+                baseScore += 20.0;
+            baseScore += (100 - planet.InfrastructureLevel) * 0.5;
+            if (ctx.Ambition is CharacterAmbition.BuildWealth or CharacterAmbition.EnsureFamilyLegacy)
+                baseScore += 15.0;
+            return Clamp0to100(baseScore);
+        }
+
+        private static double Clamp0to100(double v) => v < 0 ? 0 : (v > 100 ? 100 : v);
+    }
+}

--- a/Tests/Infrastructure/AmbitionBiasTests.cs
+++ b/Tests/Infrastructure/AmbitionBiasTests.cs
@@ -51,7 +51,8 @@ public class AmbitionBiasTests
                 { IntentType.RapePrisoner, 0.9 },
                 { IntentType.TravelToPlanet, 0.8 },
                 { IntentType.BecomePirate, 0.9 },
-                { IntentType.RaidConvoy, 0.8 }
+                { IntentType.RaidConvoy, 0.8 },
+                { IntentType.BuildInfrastructure, 0.9 }
             }
         };
 
@@ -73,7 +74,8 @@ public class AmbitionBiasTests
                 { IntentType.RapePrisoner, 0.6 },
                 { IntentType.TravelToPlanet, 1.0 },
                 { IntentType.BecomePirate, 1.2 },
-                { IntentType.RaidConvoy, 1.3 }
+                { IntentType.RaidConvoy, 1.3 },
+                { IntentType.BuildInfrastructure, 1.3 }
             }
         };
 
@@ -95,7 +97,8 @@ public class AmbitionBiasTests
                 { IntentType.RapePrisoner, 0.5 },
                 { IntentType.TravelToPlanet, 1.1 },
                 { IntentType.BecomePirate, 0.7 },
-                { IntentType.RaidConvoy, 0.6 }
+                { IntentType.RaidConvoy, 0.6 },
+                { IntentType.BuildInfrastructure, 1.2 }
             }
         };
 
@@ -117,7 +120,8 @@ public class AmbitionBiasTests
                 { IntentType.RapePrisoner, 0.7 },
                 { IntentType.TravelToPlanet, 1.3 },
                 { IntentType.BecomePirate, 1.2 },
-                { IntentType.RaidConvoy, 1.2 }
+                { IntentType.RaidConvoy, 1.2 },
+                { IntentType.BuildInfrastructure, 0.8 }
             }
         };
     }

--- a/Tests/Infrastructure/BuildInfrastructureIntentRuleTests.cs
+++ b/Tests/Infrastructure/BuildInfrastructureIntentRuleTests.cs
@@ -1,0 +1,74 @@
+using FluentAssertions;
+using Moq;
+using SkyHorizont.Domain.Entity;
+using SkyHorizont.Domain.Factions;
+using SkyHorizont.Domain.Galaxy.Planet;
+using SkyHorizont.Domain.Services;
+using SkyHorizont.Domain.Social;
+using SkyHorizont.Infrastructure.Social.IntentRules;
+using Xunit;
+
+namespace SkyHorizont.Tests.Infrastructure;
+
+public class BuildInfrastructureIntentRuleTests
+{
+    private static double GetScore(bool economyWeak = false, int infra = 80, CharacterAmbition ambition = CharacterAmbition.SeekAdventure)
+    {
+        var actorId = Guid.NewGuid();
+        var factionId = Guid.NewGuid();
+        var systemId = Guid.NewGuid();
+
+        var charRepo = Mock.Of<ICharacterRepository>();
+        var planetRepo = new Mock<IPlanetRepository>();
+        var planet = new Planet(Guid.NewGuid(), "P", systemId, factionId, new Resources(0,0,0), charRepo, planetRepo.Object, infrastructureLevel: infra, credits: 1000);
+        planet.Citizens.Add(actorId);
+        planetRepo.Setup(r => r.GetAll()).Returns(new[] { planet });
+        planetRepo.Setup(r => r.GetById(planet.Id)).Returns(planet);
+
+        var rule = new BuildInfrastructureIntentRule(planetRepo.Object);
+
+        var ctx = new IntentContext(
+            new Character(actorId, "A", 30, 1000, 1, Sex.Male, new Personality(50,50,50,50,50), new SkillSet(0,0,0,0)),
+            factionId,
+            new FactionStatus(false, false, false, economyWeak),
+            systemId,
+            null,
+            null,
+            Array.Empty<Character>(),
+            Array.Empty<Character>(),
+            Array.Empty<Character>(),
+            ambition,
+            new AmbitionBias(),
+            _ => 0,
+            _ => factionId,
+            PlannerConfig.Default);
+
+        return rule.Generate(ctx).First().Score;
+    }
+
+    [Fact]
+    public void Scores_higher_when_economy_weak()
+    {
+        var baseline = GetScore();
+        var weak = GetScore(economyWeak: true);
+        weak.Should().BeGreaterThan(baseline);
+    }
+
+    [Fact]
+    public void Scores_higher_when_infrastructure_low()
+    {
+        var baseline = GetScore();
+        var low = GetScore(infra: 20);
+        low.Should().BeGreaterThan(baseline);
+    }
+
+    [Theory]
+    [InlineData(CharacterAmbition.BuildWealth)]
+    [InlineData(CharacterAmbition.EnsureFamilyLegacy)]
+    public void Scores_higher_for_specific_ambitions(CharacterAmbition ambition)
+    {
+        var baseline = GetScore();
+        var biased = GetScore(ambition: ambition);
+        biased.Should().BeGreaterThan(baseline);
+    }
+}

--- a/Tests/Infrastructure/BuildInfrastructureResolverTests.cs
+++ b/Tests/Infrastructure/BuildInfrastructureResolverTests.cs
@@ -1,0 +1,78 @@
+using FluentAssertions;
+using Moq;
+using SkyHorizont.Domain.Entity;
+using SkyHorizont.Domain.Factions;
+using SkyHorizont.Domain.Galaxy.Planet;
+using SkyHorizont.Domain.Services;
+using SkyHorizont.Domain.Social;
+using SkyHorizont.Domain.Fleets;
+using SkyHorizont.Domain.Travel;
+using SkyHorizont.Domain.Intrigue;
+using SkyHorizont.Domain.Diplomacy;
+using SkyHorizont.Domain.Battle;
+using SkyHorizont.Infrastructure.Social;
+using Xunit;
+
+namespace SkyHorizont.Tests.Infrastructure;
+
+public class BuildInfrastructureResolverTests
+{
+    [Fact]
+    public void Resolve_build_infrastructure_invests_in_planet()
+    {
+        var actorId = Guid.NewGuid();
+        var factionId = Guid.NewGuid();
+        var systemId = Guid.NewGuid();
+
+        var actor = new Character(actorId, "A", 30, 1000, 1, Sex.Male, new Personality(50,50,50,50,50), new SkillSet(0,0,0,0));
+        var charRepo = new Mock<ICharacterRepository>();
+        charRepo.Setup(r => r.GetById(actorId)).Returns(actor);
+
+        var planetRepo = new Mock<IPlanetRepository>();
+        var planet = new Planet(Guid.NewGuid(), "Home", systemId, factionId, new Resources(0,0,0), charRepo.Object, planetRepo.Object, infrastructureLevel: 10, credits: 500);
+        planet.Citizens.Add(actorId);
+        planetRepo.Setup(r => r.GetById(planet.Id)).Returns(planet);
+        planetRepo.Setup(r => r.GetAll()).Returns(new[] { planet });
+        planetRepo.Setup(r => r.GetPlanetsControlledByFaction(factionId)).Returns(new[] { planet });
+        planetRepo.Setup(r => r.Save(It.IsAny<Planet>()));
+
+        var factionSvc = new Mock<IFactionService>();
+        factionSvc.Setup(f => f.GetFactionIdForCharacter(actorId)).Returns(factionId);
+        factionSvc.Setup(f => f.GetAllRivalFactions(factionId)).Returns(Array.Empty<Guid>());
+        factionSvc.Setup(f => f.GetEconomicStrength(factionId)).Returns(100);
+
+        var fleetRepo = new Mock<IFleetRepository>();
+        fleetRepo.Setup(f => f.GetAll()).Returns(Array.Empty<Fleet>());
+        fleetRepo.Setup(f => f.GetFleetsForFaction(factionId)).Returns(Array.Empty<Fleet>());
+
+        var piracy = new Mock<IPiracyService>();
+        piracy.Setup(p => p.GetPirateActivity(systemId)).Returns(0);
+        piracy.Setup(p => p.GetTrafficLevel(systemId)).Returns(0);
+
+        var eventBus = new Mock<IEventBus>();
+
+        var resolver = new InteractionResolver(
+            charRepo.Object,
+            Mock.Of<IOpinionRepository>(),
+            factionSvc.Object,
+            Mock.Of<ISecretsRepository>(),
+            Mock.Of<IRandomService>(),
+            Mock.Of<IDiplomacyService>(),
+            Mock.Of<ITravelService>(),
+            piracy.Object,
+            planetRepo.Object,
+            fleetRepo.Object,
+            eventBus.Object,
+            Mock.Of<IBattleOutcomeService>(),
+            Mock.Of<IIntimacyLog>(),
+            Mock.Of<IMeritPolicy>()
+        );
+
+        var intent = new CharacterIntent(actorId, IntentType.BuildInfrastructure, null, null, planet.Id);
+        var events = resolver.Resolve(intent, 3000, 1).ToList();
+
+        events.Should().HaveCount(1);
+        planet.InfrastructureLevel.Should().Be(20);
+        planet.Credits.Should().Be(300);
+    }
+}


### PR DESCRIPTION
## Summary
- extend IntentType and AmbitionBias with BuildInfrastructure intent
- plan and resolve infrastructure investments including new scoring rule
- add tests for BuildInfrastructure intent rule and resolver behavior

## Testing
- `dotnet test`


------
https://chatgpt.com/codex/tasks/task_e_68ac2f7b0e5c83218ec142e1d1a98809