### PR TITLE
Use economy repository for planet credits

### DIFF
--- a/Infrastructure/DomainServices/EconomyService.cs
+++ b/Infrastructure/DomainServices/EconomyService.cs
@@ -116,7 +116,6 @@ namespace SkyHorizont.Infrastructure.DomainServices
 
             // Debit planet (if possible)
             _eco.TryDebitBudget(planet.Id, leakage + piratesTake);
-            _planets.Save(planet);
 
             // Credit pirates (faction funds)
             _factionFunds.AddBalance(counterpartyFactionId, piratesTake);
@@ -230,7 +229,6 @@ namespace SkyHorizont.Infrastructure.DomainServices
                 }
                 else
                 {
-                    _planets.Save(planet);
                     _eco.AddEventLog(new EconomyEvent(_clock.CurrentYear, _clock.CurrentMonth,
                         "UpkeepPlanet", planet.Id, -infraUpkeep, $"Infra upkeep {infraUpkeep} (adj)"));
                 }
@@ -311,7 +309,6 @@ namespace SkyHorizont.Infrastructure.DomainServices
 
             if (_eco.TryDebitBudget(planet.Id, tax))
             {
-                _planets.Save(planet);
                 _factionFunds.AddBalance(planet.FactionId, tax);
 
                 _eco.AddEventLog(new EconomyEvent(_clock.CurrentYear, _clock.CurrentMonth,

--- a/Infrastructure/Testing/LifecycleSimulationRunner.cs
+++ b/Infrastructure/Testing/LifecycleSimulationRunner.cs
@@ -4,6 +4,8 @@ using SkyHorizont.Domain.Galaxy.Planet;
 using SkyHorizont.Domain.Services;
 using SkyHorizont.Infrastructure.DomainServices;
 using SkyHorizont.Infrastructure.Social;
+using Infrastructure.Persistence.Repositories;
+using SkyHorizont.Infrastructure.Persistence;
 
 namespace SkyHorizont.Infrastructure.Testing
 {
@@ -47,6 +49,7 @@ namespace SkyHorizont.Infrastructure.Testing
         public void SeedCoupleOnPlanet(Guid systemId)
         {
             // Create planet
+            var eco = new PlanetEconomyRepository(new InMemoryPlanetEconomyDbContext());
             var planet = new Planet(
                 id: Guid.NewGuid(),
                 name: "Testia Prime",
@@ -55,6 +58,7 @@ namespace SkyHorizont.Infrastructure.Testing
                 initialResources: new Resources(10_000, 10_000, 10_000),
                 characterRepository: _characters,
                 planetRepository: _planets,
+                economyRepository: eco,
                 initialStability: 1.0,
                 infrastructureLevel: 50,
                 baseTaxRate: 15.0

--- a/Tests/Battle/BattleSimulatorTest.cs
+++ b/Tests/Battle/BattleSimulatorTest.cs
@@ -14,6 +14,7 @@ using SkyHorizont.Domain.Factions;
 using SkyHorizont.Domain.Services;
 using SkyHorizont.Domain.Shared;
 using SkyHorizont.Infrastructure.DomainServices;
+using SkyHorizont.Domain.Economy;
 
 namespace SkyHorizont.Tests.Battle
 {
@@ -39,7 +40,8 @@ namespace SkyHorizont.Tests.Battle
         {
             var chrRepo = new Mock<ICharacterRepository>().Object;
             var planetRepo = new Mock<IPlanetRepository>().Object;
-            return new Planet(Guid.NewGuid(), "Gaia", system, faction, new Resources(100,100,100), chrRepo, planetRepo,
+            var eco = new Mock<IPlanetEconomyRepository>().Object;
+            return new Planet(Guid.NewGuid(), "Gaia", system, faction, new Resources(100,100,100), chrRepo, planetRepo, eco,
                 initialStability: 1.0, infrastructureLevel: 10, baseAtk: 0, baseDef: baseDef, troops: troops);
         }
 

--- a/Tests/Domain/PlanetSeatTests.cs
+++ b/Tests/Domain/PlanetSeatTests.cs
@@ -3,6 +3,7 @@ using FluentAssertions;
 using Xunit;
 using SkyHorizont.Domain.Galaxy.Planet;
 using SkyHorizont.Infrastructure.Persistence;
+using Infrastructure.Persistence.Repositories;
 
 namespace SkyHorizont.Tests.Domain
 {
@@ -13,7 +14,8 @@ namespace SkyHorizont.Tests.Domain
         {
             var chars = new CharactersRepository(new InMemoryCharactersDbContext());
             var planetsRepo = new PlanetsRepository(new InMemoryPlanetsDbContext());
-            var planet = new Planet(Guid.NewGuid(), "SeatWorld", Guid.NewGuid(), Guid.NewGuid(), new Resources(0, 0, 0), chars, planetsRepo);
+            var eco = new PlanetEconomyRepository(new InMemoryPlanetEconomyDbContext());
+            var planet = new Planet(Guid.NewGuid(), "SeatWorld", Guid.NewGuid(), Guid.NewGuid(), new Resources(0, 0, 0), chars, planetsRepo, eco);
             planetsRepo.Save(planet);
 
             var factionId = Guid.NewGuid();

--- a/notes.md
+++ b/notes.md
@@ -1,5 +1,9 @@
 # Notes
 
+## Ledger Consolidation
+
+Planet credit balances now live in `IPlanetEconomyRepository`, replacing direct `Planet.Credits` mutations for a single, consistent ledger.
+
 ## Features
 
 ### Social & Personal


### PR DESCRIPTION
## Summary
- route all planet credit updates through `IPlanetEconomyRepository`
- drop direct `Planet.Credits` mutations from domain and services
- clarify consolidated credit ledger in notes

## Testing
- `dotnet test`

------
https://chatgpt.com/codex/tasks/task_e_68ac367ec0c88321ac3fb79975409ffe