### PR TITLE
Enhance fleet building logic with contextual ship choices

### DIFF
--- a/Domain/Social/IntentModels.cs
+++ b/Domain/Social/IntentModels.cs
@@ -11,7 +11,7 @@ namespace SkyHorizont.Domain.Social
         FoundPirateClan,
         ExpelFromHouse,
         ClaimPlanetSeat,
-        BuildInfrastructure
+        BuildInfrastructure,
         BuildFleet
     }
 

--- a/Infrastructure/Social/IntentPlanner.cs
+++ b/Infrastructure/Social/IntentPlanner.cs
@@ -236,7 +236,7 @@ namespace SkyHorizont.Infrastructure.Social
                     TravelToPlanet = 0.8,
                     BecomePirate = 0.9,
                     RaidConvoy = 0.8,
-                    BuildInfrastructure = 0.9
+                    BuildInfrastructure = 0.9,
                     BuildFleet = 1.3
                 },
                 CharacterAmbition.BuildWealth => bias with
@@ -255,7 +255,7 @@ namespace SkyHorizont.Infrastructure.Social
                     TravelToPlanet = 1.0,
                     BecomePirate = 1.2,
                     RaidConvoy = 1.3,
-                    BuildInfrastructure = 1.3
+                    BuildInfrastructure = 1.3,
                     BuildFleet = 0.8
                 },
                 CharacterAmbition.EnsureFamilyLegacy => bias with
@@ -274,7 +274,7 @@ namespace SkyHorizont.Infrastructure.Social
                     TravelToPlanet = 1.1,
                     BecomePirate = 0.7,
                     RaidConvoy = 0.6,
-                    BuildInfrastructure = 1.2
+                    BuildInfrastructure = 1.2,
                     BuildFleet = 0.7
                 },
                 CharacterAmbition.SeekAdventure => bias with
@@ -293,7 +293,7 @@ namespace SkyHorizont.Infrastructure.Social
                     TravelToPlanet = 1.3,
                     BecomePirate = 1.2,
                     RaidConvoy = 1.2,
-                    BuildInfrastructure = 0.8
+                    BuildInfrastructure = 0.8,
                     BuildFleet = 1.2
                 },
                 _ => bias

--- a/Infrastructure/Social/IntentRules/BuildFleetIntentRule.cs
+++ b/Infrastructure/Social/IntentRules/BuildFleetIntentRule.cs
@@ -1,16 +1,19 @@
 using System.Linq;
 using SkyHorizont.Domain.Fleets;
 using SkyHorizont.Domain.Social;
+using SkyHorizont.Domain.Travel;
 
 namespace SkyHorizont.Infrastructure.Social.IntentRules
 {
     public sealed class BuildFleetIntentRule : IIntentRule
     {
         private readonly IFleetRepository _fleets;
+        private readonly IPiracyService _piracy;
 
-        public BuildFleetIntentRule(IFleetRepository fleets)
+        public BuildFleetIntentRule(IFleetRepository fleets, IPiracyService piracy)
         {
             _fleets = fleets;
+            _piracy = piracy;
         }
 
         public IEnumerable<ScoredIntent> Generate(IntentContext ctx)
@@ -23,6 +26,9 @@ namespace SkyHorizont.Infrastructure.Social.IntentRules
             else if (strength < 300) score += 20;
 
             if (ctx.FactionStatus.IsAtWar) score += 40;
+            if (ctx.SystemSecurity?.PirateActivity > 50) score += 25;
+            if (ctx.SystemSecurity?.Traffic > 80) score += 15;
+            if (_piracy.IsPirateFaction(ctx.ActorFactionId)) score += 30;
 
             score *= ctx.AmbitionBias.BuildFleet;
 

--- a/Infrastructure/Social/InteractionResolver.cs
+++ b/Infrastructure/Social/InteractionResolver.cs
@@ -1364,23 +1364,66 @@ namespace SkyHorizont.Infrastructure.Social
         #region Build Fleet
         private IEnumerable<ISocialEvent> ResolveBuildFleet(Character actor, CharacterIntent intent, int y, int m, Guid actorFactionId, Guid? actorSystemId)
         {
-            const int cost = 1000;
+            var factionStatus = GetFactionStatus(actorFactionId);
+            var isPirateFaction = _piracy.IsPirateFaction(actorFactionId);
+            var system = actorSystemId ?? Guid.Empty;
+            var security = actorSystemId.HasValue ? GetSystemSecurity(actorSystemId.Value) : null;
+
+            // Determine ship type based on context
+            ShipClass chosenClass;
+            int buildCost;
+            double atk, def, cargo, speed;
+
+            if (isPirateFaction)
+            {
+                chosenClass = ShipClass.Corvette; // fast raiders
+                buildCost = 800;
+                atk = 10; def = 8; cargo = 5; speed = 2.5;
+            }
+            else if (factionStatus.IsAtWar || (security?.PirateActivity ?? 0) > 50)
+            {
+                // need combat ships
+                chosenClass = actor.Personality.Agreeableness < 40 ? ShipClass.Destroyer : ShipClass.Frigate;
+                if (chosenClass == ShipClass.Destroyer)
+                {
+                    buildCost = 2500; atk = 30; def = 25; cargo = 15; speed = 1.3;
+                }
+                else
+                {
+                    buildCost = 1500; atk = 20; def = 20; cargo = 20; speed = 1.5;
+                }
+            }
+            else if ((security?.Traffic ?? 0) > 80)
+            {
+                // trade hub
+                chosenClass = ShipClass.Freighter;
+                buildCost = 1200; atk = 5; def = 8; cargo = 100; speed = 1.5;
+            }
+            else
+            {
+                chosenClass = ShipClass.Corvette;
+                buildCost = 800; atk = 10; def = 10; cargo = 10; speed = 2;
+            }
+
+            // include initial maintenance charge
+            int maintenance = (int)Math.Ceiling(buildCost * 0.1);
+            int totalCost = buildCost + maintenance;
+
             bool success = false;
             string notes;
 
-            if (!_funds.HasFunds(actorFactionId, cost))
+            if (!_funds.HasFunds(actorFactionId, totalCost))
             {
                 notes = "Insufficient funds to build fleet.";
             }
             else
             {
-                _funds.Deduct(actorFactionId, cost);
-                var system = actorSystemId ?? Guid.Empty;
+                _funds.Deduct(actorFactionId, totalCost);
                 var fleet = new Fleet(Guid.NewGuid(), actorFactionId, system, _piracy);
-                fleet.AddShip(new Ship(Guid.NewGuid(), ShipClass.Corvette, 10, 10, 10, 2, 0));
+                fleet.AddShip(new Ship(Guid.NewGuid(), chosenClass, atk, def, cargo, speed, buildCost));
                 _fleets.Save(fleet);
                 success = true;
-                notes = "New fleet commissioned.";
+                notes = $"New {chosenClass} commissioned (maintenance {maintenance}).";
             }
 
             var ev = new SocialEvent(Guid.NewGuid(), y, m, SocialEventType.BuildFleet, actor.Id, null, null, null, success, 0, 0, Array.Empty<Guid>(), notes);

--- a/Tests/Infrastructure/BuildInfrastructureIntentRuleTests.cs
+++ b/Tests/Infrastructure/BuildInfrastructureIntentRuleTests.cs
@@ -1,11 +1,14 @@
 using FluentAssertions;
 using Moq;
 using SkyHorizont.Domain.Entity;
+using Moq;
 using SkyHorizont.Domain.Factions;
 using SkyHorizont.Domain.Galaxy.Planet;
 using SkyHorizont.Domain.Services;
 using SkyHorizont.Domain.Social;
 using SkyHorizont.Infrastructure.Social.IntentRules;
+using Infrastructure.Persistence.Repositories;
+using SkyHorizont.Infrastructure.Persistence;
 using Xunit;
 
 namespace SkyHorizont.Tests.Infrastructure;
@@ -19,8 +22,9 @@ public class BuildInfrastructureIntentRuleTests
         var systemId = Guid.NewGuid();
 
         var charRepo = Mock.Of<ICharacterRepository>();
+        var ecoRepo = new PlanetEconomyRepository(new InMemoryPlanetEconomyDbContext());
         var planetRepo = new Mock<IPlanetRepository>();
-        var planet = new Planet(Guid.NewGuid(), "P", systemId, factionId, new Resources(0,0,0), charRepo, planetRepo.Object, infrastructureLevel: infra, credits: 1000);
+        var planet = new Planet(Guid.NewGuid(), "P", systemId, factionId, new Resources(0,0,0), charRepo, planetRepo.Object, ecoRepo, infrastructureLevel: infra, credits: 1000);
         planet.Citizens.Add(actorId);
         planetRepo.Setup(r => r.GetAll()).Returns(new[] { planet });
         planetRepo.Setup(r => r.GetById(planet.Id)).Returns(planet);

--- a/Tests/Infrastructure/BuildInfrastructureResolverTests.cs
+++ b/Tests/Infrastructure/BuildInfrastructureResolverTests.cs
@@ -11,6 +11,8 @@ using SkyHorizont.Domain.Intrigue;
 using SkyHorizont.Domain.Diplomacy;
 using SkyHorizont.Domain.Battle;
 using SkyHorizont.Infrastructure.Social;
+using Infrastructure.Persistence.Repositories;
+using SkyHorizont.Infrastructure.Persistence;
 using Xunit;
 
 namespace SkyHorizont.Tests.Infrastructure;
@@ -28,8 +30,9 @@ public class BuildInfrastructureResolverTests
         var charRepo = new Mock<ICharacterRepository>();
         charRepo.Setup(r => r.GetById(actorId)).Returns(actor);
 
+        var ecoRepo = new PlanetEconomyRepository(new InMemoryPlanetEconomyDbContext());
         var planetRepo = new Mock<IPlanetRepository>();
-        var planet = new Planet(Guid.NewGuid(), "Home", systemId, factionId, new Resources(0,0,0), charRepo.Object, planetRepo.Object, infrastructureLevel: 10, credits: 500);
+        var planet = new Planet(Guid.NewGuid(), "Home", systemId, factionId, new Resources(0,0,0), charRepo.Object, planetRepo.Object, ecoRepo, infrastructureLevel: 10, credits: 500);
         planet.Citizens.Add(actorId);
         planetRepo.Setup(r => r.GetById(planet.Id)).Returns(planet);
         planetRepo.Setup(r => r.GetAll()).Returns(new[] { planet });
@@ -62,6 +65,7 @@ public class BuildInfrastructureResolverTests
             piracy.Object,
             planetRepo.Object,
             fleetRepo.Object,
+            Mock.Of<IFundsService>(),
             eventBus.Object,
             Mock.Of<IBattleOutcomeService>(),
             Mock.Of<IIntimacyLog>(),

--- a/Tests/Infrastructure/Economy/EconomyServiceTradeTests.cs
+++ b/Tests/Infrastructure/Economy/EconomyServiceTradeTests.cs
@@ -11,7 +11,7 @@ using SkyHorizont.Domain.Galaxy.Planet;
 using SkyHorizont.Domain.Services;
 using SkyHorizont.Infrastructure.DomainServices;
 using SkyHorizont.Infrastructure.Persistence;
-using SkyHorizont.Infrastructure.Persistence.Repositories;
+using Infrastructure.Persistence.Repositories;
 using Xunit;
 
 namespace SkyHorizont.Tests.Infrastructure.Economy;
@@ -60,10 +60,10 @@ public class EconomyServiceTradeTests
         public void AdvanceTurn() { }
     }
 
-    private static Planet CreatePlanet(Guid id, Guid systemId, Guid factionId, IPlanetRepository repo, ICharacterRepository chars)
+    private static Planet CreatePlanet(Guid id, Guid systemId, Guid factionId, IPlanetRepository repo, ICharacterRepository chars, IPlanetEconomyRepository eco)
     {
         var planet = new Planet(id, $"P{id.ToString()[..4]}", systemId, factionId,
-            new Resources(0, 0, 0), chars, repo, infrastructureLevel: 0);
+            new Resources(0, 0, 0), chars, repo, eco, infrastructureLevel: 0);
         repo.Save(planet);
         return planet;
     }
@@ -82,13 +82,12 @@ public class EconomyServiceTradeTests
         starmap.RegisterPirate(pirate1, systemA);
         starmap.RegisterPirate(pirate2, systemB);
 
+        var ecoRepo = new PlanetEconomyRepository(new InMemoryPlanetEconomyDbContext());
         var planetCtx = new InMemoryPlanetsDbContext();
         var planetRepo = new PlanetsRepository(planetCtx);
         var charRepo = Mock.Of<ICharacterRepository>(c => c.GetAll() == Array.Empty<Character>() && c.GetLiving() == Array.Empty<Character>());
-        var planetA = CreatePlanet(Guid.NewGuid(), systemA, Guid.NewGuid(), planetRepo, charRepo);
-        var planetB = CreatePlanet(Guid.NewGuid(), systemB, Guid.NewGuid(), planetRepo, charRepo);
-
-        var ecoRepo = new PlanetEconomyRepository(new InMemoryPlanetEconomyDbContext());
+        var planetA = CreatePlanet(Guid.NewGuid(), systemA, Guid.NewGuid(), planetRepo, charRepo, ecoRepo);
+        var planetB = CreatePlanet(Guid.NewGuid(), systemB, Guid.NewGuid(), planetRepo, charRepo, ecoRepo);
         var fundsRepo = new FactionFundsRepository(new InMemoryFundsDbContext());
         var fleetRepo = Mock.Of<IFleetRepository>(f => f.GetAll() == Array.Empty<Fleet>());
         var factionService = Mock.Of<IFactionService>();
@@ -116,14 +115,13 @@ public class EconomyServiceTradeTests
         starmap.SetSystem(systemB, 100, 0);
         starmap.SetSystem(systemC, 10, 0);
 
+        var ecoRepo = new PlanetEconomyRepository(new InMemoryPlanetEconomyDbContext());
         var planetCtx = new InMemoryPlanetsDbContext();
         var planetRepo = new PlanetsRepository(planetCtx);
         var charRepo = Mock.Of<ICharacterRepository>(c => c.GetAll() == Array.Empty<Character>() && c.GetLiving() == Array.Empty<Character>());
-        var planetA = CreatePlanet(Guid.NewGuid(), systemA, Guid.NewGuid(), planetRepo, charRepo);
-        var planetB = CreatePlanet(Guid.NewGuid(), systemB, Guid.NewGuid(), planetRepo, charRepo);
-        var planetC = CreatePlanet(Guid.NewGuid(), systemC, Guid.NewGuid(), planetRepo, charRepo);
-
-        var ecoRepo = new PlanetEconomyRepository(new InMemoryPlanetEconomyDbContext());
+        var planetA = CreatePlanet(Guid.NewGuid(), systemA, Guid.NewGuid(), planetRepo, charRepo, ecoRepo);
+        var planetB = CreatePlanet(Guid.NewGuid(), systemB, Guid.NewGuid(), planetRepo, charRepo, ecoRepo);
+        var planetC = CreatePlanet(Guid.NewGuid(), systemC, Guid.NewGuid(), planetRepo, charRepo, ecoRepo);
         var fundsRepo = new FactionFundsRepository(new InMemoryFundsDbContext());
         var fleetRepo = Mock.Of<IFleetRepository>(f => f.GetAll() == Array.Empty<Fleet>());
         var factionService = Mock.Of<IFactionService>();


### PR DESCRIPTION
## Summary
- Expand `ResolveBuildFleet` to choose ship classes and cost based on war status, piracy, trade traffic, and faction traits, including an upfront maintenance charge
- Factor pirate activity, traffic levels, and pirate factions into the build-fleet intent rule
- Tie build-fleet ambition biases into the planner and fix intent enumeration

## Testing
- `dotnet test`


------
https://chatgpt.com/codex/tasks/task_e_68ac4ae5200c83219a9a57ab2ea688bc