### PR TITLE
Charge fleet construction to planetary budgets

### DIFF
--- a/Tests/Common/LifeCycleTest.cs
+++ b/Tests/Common/LifeCycleTest.cs
@@ -51,7 +51,6 @@ namespace SkyHorizont.Tests.Common
             var travel = new TravelService(planets, fleets, rng, travels, piracy, clock);
             var fund = new CharacterFundsService(funds);
             var tax = new FactionTaxService(factionFunds, funds, planets, eco, faction, characters, clock);
-            var factionFundsSvc = new FundsService(factionFunds);
             var moral = new MoraleService(characters);
             var battle = new BattleOutcomeService(fund, factionFunds, tax, characters, moral);
             var affection = new AffectionService(characters, planets, fleets, affections);
@@ -67,7 +66,7 @@ namespace SkyHorizont.Tests.Common
             };
             var planner = new IntentPlanner(characters, opinions, faction, rng, planets, fleets, piracy, rules);
             var diplomacy = new DiplomacyService(diplomacies, faction, clock, opinions);
-            var resolver = new InteractionResolver(characters, opinions, faction, secrets, rng, diplomacy, travel, piracy, planets, fleets, factionFundsSvc, events, battle, intimacy, merit);
+            var resolver = new InteractionResolver(characters, opinions, faction, secrets, rng, diplomacy, travel, piracy, planets, fleets, eco, events, battle, intimacy, merit);
 
             var lifecycle = new CharacterLifecycleService(
                 characters, lineage, clock, rng, mortality, nameGen,

--- a/Tests/Infrastructure/BuildFleetResolverTests.cs
+++ b/Tests/Infrastructure/BuildFleetResolverTests.cs
@@ -14,6 +14,7 @@ using SkyHorizont.Domain.Intrigue;
 using SkyHorizont.Domain.Diplomacy;
 using SkyHorizont.Domain.Battle;
 using SkyHorizont.Infrastructure.Persistence.Repositories;
+using SkyHorizont.Domain.Economy;
 
 namespace SkyHorizont.Tests.Infrastructure;
 
@@ -27,9 +28,9 @@ public class BuildFleetResolverTests
         Character actor,
         Planet planet,
         IFleetRepository fleetRepo,
-        IFundsService funds,
         IFactionService factionSvc,
-        IPiracyService piracy)
+        IPiracyService piracy,
+        IPlanetEconomyRepository economy)
     {
         var charRepo = new Mock<ICharacterRepository>();
         charRepo.Setup(c => c.GetById(actor.Id)).Returns(actor);
@@ -50,7 +51,7 @@ public class BuildFleetResolverTests
             piracy,
             planetRepo.Object,
             fleetRepo,
-            funds,
+            economy,
             Mock.Of<IEventBus>(),
             Mock.Of<IBattleOutcomeService>(),
             Mock.Of<IIntimacyLog>(),
@@ -80,7 +81,7 @@ public class BuildFleetResolverTests
         var ecoRepo = new PlanetEconomyRepository(new InMemoryPlanetEconomyDbContext());
         var planet = new Planet(Guid.NewGuid(), "Home", Guid.NewGuid(), factionId,
             new Resources(500,500,500), Mock.Of<ICharacterRepository>(), Mock.Of<IPlanetRepository>(),
-            ecoRepo, productionCapacity: 500);
+            ecoRepo, credits: 20000, productionCapacity: 500);
         planet.Citizens.Add(actor.Id);
 
         var fleetRepo = new Mock<IFleetRepository>();
@@ -88,11 +89,7 @@ public class BuildFleetResolverTests
         Fleet? savedFleet = null;
         fleetRepo.Setup(f => f.Save(It.IsAny<Fleet>())).Callback<Fleet>(f => savedFleet = f);
 
-        var funds = new Mock<IFundsService>();
-        funds.Setup(f => f.GetBalance(factionId)).Returns(20000);
-        funds.Setup(f => f.Deduct(It.IsAny<Guid>(), It.IsAny<int>()));
-
-        var resolver = CreateResolver(actor, planet, fleetRepo.Object, funds.Object, factionSvc.Object, piracy.Object);
+        var resolver = CreateResolver(actor, planet, fleetRepo.Object, factionSvc.Object, piracy.Object, ecoRepo);
         var intent = new CharacterIntent(actor.Id, IntentType.BuildFleet);
 
         var ev = resolver.Resolve(intent, 3000, 1).Single();
@@ -125,7 +122,7 @@ public class BuildFleetResolverTests
         var ecoRepo = new PlanetEconomyRepository(new InMemoryPlanetEconomyDbContext());
         var planet = new Planet(Guid.NewGuid(), "Home", Guid.NewGuid(), factionId,
             new Resources(500,500,500), Mock.Of<ICharacterRepository>(), Mock.Of<IPlanetRepository>(),
-            ecoRepo, productionCapacity: 500);
+            ecoRepo, credits: 20000, productionCapacity: 500);
         planet.Citizens.Add(actor.Id);
 
         var fleetRepo = new Mock<IFleetRepository>();
@@ -133,11 +130,7 @@ public class BuildFleetResolverTests
         Fleet? savedFleet = null;
         fleetRepo.Setup(f => f.Save(It.IsAny<Fleet>())).Callback<Fleet>(f => savedFleet = f);
 
-        var funds = new Mock<IFundsService>();
-        funds.Setup(f => f.GetBalance(factionId)).Returns(20000);
-        funds.Setup(f => f.Deduct(It.IsAny<Guid>(), It.IsAny<int>()));
-
-        var resolver = CreateResolver(actor, planet, fleetRepo.Object, funds.Object, factionSvc.Object, piracy.Object);
+        var resolver = CreateResolver(actor, planet, fleetRepo.Object, factionSvc.Object, piracy.Object, ecoRepo);
         var intent = new CharacterIntent(actor.Id, IntentType.BuildFleet);
 
         var ev = resolver.Resolve(intent, 3000, 1).Single();
@@ -172,7 +165,7 @@ public class BuildFleetResolverTests
         var ecoRepo = new PlanetEconomyRepository(new InMemoryPlanetEconomyDbContext());
         var planet = new Planet(Guid.NewGuid(), "Home", Guid.NewGuid(), factionId,
             new Resources(1000,1000,1000), Mock.Of<ICharacterRepository>(), Mock.Of<IPlanetRepository>(),
-            ecoRepo, productionCapacity: 500);
+            ecoRepo, credits: 20000, productionCapacity: 500);
         planet.Citizens.Add(actor.Id);
 
         Fleet? savedFleet = null;
@@ -182,11 +175,7 @@ public class BuildFleetResolverTests
             .Returns(() => new[] { savedFleet! });
         fleetRepo.Setup(f => f.Save(It.IsAny<Fleet>())).Callback<Fleet>(f => savedFleet = f);
 
-        var funds = new Mock<IFundsService>();
-        funds.Setup(f => f.GetBalance(factionId)).Returns(20000);
-        funds.Setup(f => f.Deduct(It.IsAny<Guid>(), It.IsAny<int>()));
-
-        var resolver = CreateResolver(actor, planet, fleetRepo.Object, funds.Object, factionSvc.Object, piracy.Object);
+        var resolver = CreateResolver(actor, planet, fleetRepo.Object, factionSvc.Object, piracy.Object, ecoRepo);
         var intent = new CharacterIntent(actor.Id, IntentType.BuildFleet);
 
         resolver.Resolve(intent, 3000, 1); // initial build

--- a/Tests/Infrastructure/BuildInfrastructureResolverTests.cs
+++ b/Tests/Infrastructure/BuildInfrastructureResolverTests.cs
@@ -76,7 +76,7 @@ public class BuildInfrastructureResolverTests
             piracy.Object,
             planetRepo.Object,
             fleetRepo.Object,
-            Mock.Of<IFundsService>(),
+            ecoRepo.Object,
             eventBus.Object,
             Mock.Of<IBattleOutcomeService>(),
             Mock.Of<IIntimacyLog>(),


### PR DESCRIPTION
## Summary
- Deduct fleet-building costs from planetary treasuries via `IPlanetEconomyRepository`
- Update tests and harnesses to use planet economy instead of faction funds

## Testing
- `dotnet test` *(fails: command not found)*
- `apt-get install -y dotnet-sdk-7.0` *(fails: Unable to locate package)*

------
https://chatgpt.com/codex/tasks/task_e_68ac70487d5c832189d89e1670c71824