### PR TITLE
Remove plots with dead leaders

### DIFF
--- a/Infrastructure/DomainServices/IntrigueService.cs
+++ b/Infrastructure/DomainServices/IntrigueService.cs
@@ -62,7 +62,10 @@ namespace SkyHorizont.Infrastructure.DomainServices
 
                 var leader = _characters.GetById(plot.LeaderId);
                 if (leader is null || !leader.IsAlive)
+                {
+                    _plots.Remove(plot.PlotId);
                     continue;
+                }
 
                 // Progress speed from conspirators' Intelligence + leader’s Conscientiousness
                 var conspirators = plot.Conspirators

--- a/Tests/Infrastructure/IntrigueServiceTests.cs
+++ b/Tests/Infrastructure/IntrigueServiceTests.cs
@@ -1,0 +1,55 @@
+using System;
+using System.Linq;
+using FluentAssertions;
+using Moq;
+using SkyHorizont.Domain.Entity;
+using SkyHorizont.Domain.Factions;
+using SkyHorizont.Domain.Intrigue;
+using SkyHorizont.Domain.Social;
+using SkyHorizont.Domain.Services;
+using SkyHorizont.Infrastructure.DomainServices;
+using SkyHorizont.Infrastructure.Persistence.Intrigue;
+using Xunit;
+
+namespace SkyHorizont.Tests.Infrastructure;
+
+public class IntrigueServiceTests
+{
+    [Fact]
+    public void TickPlots_removes_plots_with_dead_leader()
+    {
+        var ctx = new InMemoryIntrigueDbContext();
+        var plotRepo = new PlotRepository(ctx);
+        var leaderId = Guid.NewGuid();
+        plotRepo.Create(leaderId, "goal", Enumerable.Empty<Guid>(), Enumerable.Empty<Guid>());
+
+        var leader = new Character(
+            leaderId,
+            "Leader",
+            30,
+            0,
+            1,
+            Sex.Male,
+            new Personality(10,10,10,10,10),
+            new SkillSet(10,10,10,10));
+        leader.MarkDead();
+
+        var charRepo = new Mock<ICharacterRepository>();
+        charRepo.Setup(c => c.GetById(leaderId)).Returns(leader);
+
+        var service = new IntrigueService(
+            plotRepo,
+            Mock.Of<ISecretsRepository>(),
+            Mock.Of<IOpinionRepository>(),
+            Mock.Of<IFactionService>(),
+            charRepo.Object,
+            Mock.Of<IIntelService>(),
+            Mock.Of<IRandomService>(),
+            Mock.Of<IGameClockService>());
+
+        service.TickPlots();
+
+        plotRepo.GetAll().Should().BeEmpty();
+    }
+}
+


### PR DESCRIPTION
## Summary
- delete intrigue plots when their leader is missing or dead
- add a test ensuring dead-led plots are removed during ticks

## Testing
- `dotnet test` *(fails: Cannot use local variable 'planet' before it is declared)*

------
https://chatgpt.com/codex/tasks/task_e_68ad617401a88321abb3043bfb7613d2