### PR TITLE
Clean conspirator list before intrigue ticks

### DIFF
--- a/Infrastructure/Social/InteractionResolver.cs
+++ b/Infrastructure/Social/InteractionResolver.cs
@@ -1390,6 +1390,7 @@ namespace SkyHorizont.Infrastructure.Social
             var security = actorSystemId.HasValue ? GetSystemSecurity(actorSystemId.Value) : null;
             var faction = _factions.GetFaction(actorFactionId);
 
+            var planet = planets[0];
             int funds = planet.Credits;
             int econStrength = _factions.GetEconomicStrength(actorFactionId);
             int budget = Math.Min(funds, (int)(econStrength * 0.5));
@@ -1399,7 +1400,6 @@ namespace SkyHorizont.Infrastructure.Social
                 return new[] { ev };
             }
 
-            var planet = planets[0];
             var fleet = _fleets.GetFleetsForFaction(actorFactionId).FirstOrDefault();
             if (fleet == null)
             {


### PR DESCRIPTION
## Summary
- Build new conspirator list from only living characters before processing plot ticks
- Use cleaned list for exposure and recruitment calculations
- Add regression test ensuring dead conspirators are removed
- Fix InteractionResolver compile issue by initializing planet before use

## Testing
- `dotnet test`


------
https://chatgpt.com/codex/tasks/task_e_68ad6ac25fe08321ac17669d7cd206a7