### PR TITLE
Enable prisoner exchanges for ransom negotiation

### DIFF
--- a/Domain/Factions/Faction.cs
+++ b/Domain/Factions/Faction.cs
@@ -60,6 +60,18 @@ namespace SkyHorizont.Domain.Factions
                 : new DiplomaticStanding(0);
         }
 
+        /// <summary>
+        /// Adjusts diplomacy with another faction by the specified amount.
+        /// Positive values improve goodwill while negative values increase hostility.
+        /// </summary>
+        public void AdjustDiplomacy(Guid otherFactionId, int change)
+        {
+            var newVal = _diplomacy.TryGetValue(otherFactionId, out var current)
+                ? current.Adjust(change)
+                : new DiplomaticStanding(change);
+            _diplomacy[otherFactionId] = newVal;
+        }
+
         public void ConquerPlanet(Guid planetId)
         {
             if (!_planetIds.Add(planetId))

--- a/Domain/Factions/IFactionService.cs
+++ b/Domain/Factions/IFactionService.cs
@@ -14,6 +14,12 @@ namespace SkyHorizont.Domain.Factions
         bool HasAlliance(Guid factionA, Guid factionB);
         int GetEconomicStrength(Guid factionId);
 
+        /// <summary>
+        /// Attempt to negotiate a prisoner exchange between factions of the payer and captive.
+        /// Returns true if an exchange or deferment was arranged.
+        /// </summary>
+        bool NegotiatePrisonerExchange(Guid payerId, Guid captiveId);
+
         void MoveCharacterToFaction(Guid characterId, Guid newFactionId);
         void Save(Faction faction);
         Faction GetFaction(Guid factionId);

--- a/Infrastructure/DomainServices/FactionService.cs
+++ b/Infrastructure/DomainServices/FactionService.cs
@@ -65,6 +65,25 @@ namespace SkyHorizont.Domain.Factions
             return planetCount > 0 ? (int)((totalInfrastructure + totalStability) / (2 * planetCount)) : 0;
         }
 
+        public bool NegotiatePrisonerExchange(Guid payerId, Guid captiveId)
+        {
+            var payerFactionId = GetFactionIdForCharacter(payerId);
+            var captorFactionId = GetFactionIdForCharacter(captiveId);
+            if (payerFactionId == Guid.Empty || captorFactionId == Guid.Empty)
+                return false;
+
+            var payerFaction = _factionRepository.GetFaction(payerFactionId);
+            var captorFaction = _factionRepository.GetFaction(captorFactionId);
+            if (payerFaction == null || captorFaction == null)
+                return false;
+
+            bool success = !IsAtWar(payerFactionId, captorFactionId);
+            var delta = success ? 5 : -5;
+            payerFaction.AdjustDiplomacy(captorFactionId, delta);
+            captorFaction.AdjustDiplomacy(payerFactionId, delta);
+            return success;
+        }
+
         public IEnumerable<Guid> GetAllRivalFactions(Guid forFaction)
         {
             if (forFaction == Guid.Empty) return Enumerable.Empty<Guid>();

--- a/Infrastructure/DomainServices/RansomService.cs
+++ b/Infrastructure/DomainServices/RansomService.cs
@@ -17,6 +17,7 @@ namespace SkyHorizont.Infrastructure.DomainServices
         private readonly IPlanetRepository _planetRepo;
         private readonly IFleetRepository _fleetRepo;
         private readonly IRansomDecisionService _decision;
+        private readonly IFactionService _factions;
 
         public RansomService(
             ICharacterRepository characterRepository,
@@ -24,7 +25,8 @@ namespace SkyHorizont.Infrastructure.DomainServices
             IFactionFundsRepository fleetRepository,
             IPlanetRepository planetRepo,
             IFleetRepository fleetRepo,
-            IRansomDecisionService decisionService)
+            IRansomDecisionService decisionService,
+            IFactionService factionService)
         {
             _cmdRepo = characterRepository;
             _funds = characterFundsService;
@@ -32,6 +34,7 @@ namespace SkyHorizont.Infrastructure.DomainServices
             _planetRepo = planetRepo;
             _fleetRepo = fleetRepo;
             _decision = decisionService;
+            _factions = factionService;
         }
 
         /// <summary>
@@ -42,9 +45,9 @@ namespace SkyHorizont.Infrastructure.DomainServices
         public bool TryResolveRansom(Guid payerId, Guid captiveId, int amount)
         {
             if (!_decision.WillPayRansom(payerId, captiveId, amount))
-                return false;
+                return _factions.NegotiatePrisonerExchange(payerId, captiveId);
             if (!_funds.DeductCharacter(payerId, amount))
-                return false;
+                return _factions.NegotiatePrisonerExchange(payerId, captiveId);
             _funds.CreditCharacter(captiveId, amount);
             return true;
         }

--- a/Tests/Domain/ChildInheritanceVariationTests.cs
+++ b/Tests/Domain/ChildInheritanceVariationTests.cs
@@ -101,6 +101,7 @@ namespace SkyHorizont.Tests.Domain
             public void MoveCharacterToFaction(Guid characterId, Guid newFactionId) { }
             public void Save(Faction faction) { }
             public Faction GetFaction(Guid factionId) => new Faction(factionId, "Dummy", Guid.Empty);
+            public bool NegotiatePrisonerExchange(Guid payerId, Guid captiveId) => false;
         }
 
         private sealed class FixedLocationService : ILocationService

--- a/Tests/Domain/ChildNamingTests.cs
+++ b/Tests/Domain/ChildNamingTests.cs
@@ -127,6 +127,7 @@ namespace SkyHorizont.Tests.Domain
             public void MoveCharacterToFaction(Guid characterId, Guid newFactionId) { }
             public void Save(Faction faction) { }
             public Faction GetFaction(Guid factionId) => new Faction(factionId, "Dummy", Guid.Empty);
+            public bool NegotiatePrisonerExchange(Guid payerId, Guid captiveId) => false;
         }
     }
 }

--- a/Tests/Infrastructure/FactionServiceNegotiationTests.cs
+++ b/Tests/Infrastructure/FactionServiceNegotiationTests.cs
@@ -1,0 +1,64 @@
+using FluentAssertions;
+using Moq;
+using SkyHorizont.Domain.Factions;
+using SkyHorizont.Domain.Galaxy.Planet;
+using SkyHorizont.Infrastructure.DomainServices;
+using SkyHorizont.Infrastructure.Persistence;
+using SkyHorizont.Infrastructure.Repository;
+using SkyHorizont.Infrastructure.Utility;
+using Xunit;
+
+namespace SkyHorizont.Tests.Infrastructure;
+
+public class FactionServiceNegotiationTests
+{
+    [Fact]
+    public void NegotiatePrisonerExchange_Succeeds_AdjustsGoodwill()
+    {
+        var ctx = new InMemoryFactionsDbContext();
+        var repo = new FactionRepository(ctx);
+        var svc = new FactionService(repo, Mock.Of<IPlanetRepository>());
+
+        var factionA = new Faction(Guid.NewGuid(), "A", Guid.NewGuid());
+        var factionB = new Faction(Guid.NewGuid(), "B", Guid.NewGuid());
+        ctx.Factions[factionA.Id] = factionA;
+        ctx.Factions[factionB.Id] = factionB;
+
+        var charA = Guid.NewGuid();
+        var charB = Guid.NewGuid();
+        ctx.MapCharacterToFaction(charA, factionA.Id);
+        ctx.MapCharacterToFaction(charB, factionB.Id);
+
+        var result = svc.NegotiatePrisonerExchange(charA, charB);
+
+        result.Should().BeTrue();
+        factionA.Diplomacy[factionB.Id].Value.Should().BeGreaterThan(0);
+        factionB.Diplomacy[factionA.Id].Value.Should().BeGreaterThan(0);
+    }
+
+    [Fact]
+    public void NegotiatePrisonerExchange_FailsDueToWar_AdjustsHostility()
+    {
+        var ctx = new InMemoryFactionsDbContext();
+        var repo = new FactionRepository(ctx);
+        var svc = new FactionService(repo, Mock.Of<IPlanetRepository>());
+
+        var factionA = new Faction(Guid.NewGuid(), "A", Guid.NewGuid());
+        var factionB = new Faction(Guid.NewGuid(), "B", Guid.NewGuid());
+        ctx.Factions[factionA.Id] = factionA;
+        ctx.Factions[factionB.Id] = factionB;
+
+        var charA = Guid.NewGuid();
+        var charB = Guid.NewGuid();
+        ctx.MapCharacterToFaction(charA, factionA.Id);
+        ctx.MapCharacterToFaction(charB, factionB.Id);
+        ctx.AddWar(factionA.Id, factionB.Id);
+
+        var result = svc.NegotiatePrisonerExchange(charA, charB);
+
+        result.Should().BeFalse();
+        factionA.Diplomacy[factionB.Id].Value.Should().BeLessThan(0);
+        factionB.Diplomacy[factionA.Id].Value.Should().BeLessThan(0);
+    }
+}
+

--- a/Tests/Infrastructure/RansomServiceTests.cs
+++ b/Tests/Infrastructure/RansomServiceTests.cs
@@ -13,7 +13,7 @@ namespace SkyHorizont.Tests.Infrastructure;
 public class RansomServiceTests
 {
     [Fact]
-    public void TryResolveRansom_PayerRefuses_DoesNotDeductFunds()
+    public void TryResolveRansom_PayerRefuses_ExchangeFails_DoesNotDeductFunds()
     {
         var payerId = Guid.NewGuid();
         var captiveId = Guid.NewGuid();
@@ -21,7 +21,9 @@ public class RansomServiceTests
 
         var funds = new Mock<ICharacterFundsService>();
         var decision = new Mock<IRansomDecisionService>();
+        var factions = new Mock<IFactionService>();
         decision.Setup(d => d.WillPayRansom(payerId, captiveId, amount)).Returns(false);
+        factions.Setup(f => f.NegotiatePrisonerExchange(payerId, captiveId)).Returns(false);
 
         var service = new RansomService(
             Mock.Of<ICharacterRepository>(),
@@ -29,11 +31,42 @@ public class RansomServiceTests
             Mock.Of<IFactionFundsRepository>(),
             Mock.Of<IPlanetRepository>(),
             Mock.Of<IFleetRepository>(),
-            decision.Object);
+            decision.Object,
+            factions.Object);
 
         var result = service.TryResolveRansom(payerId, captiveId, amount);
 
         result.Should().BeFalse();
         funds.Verify(f => f.DeductCharacter(It.IsAny<Guid>(), It.IsAny<int>()), Times.Never);
+        factions.Verify(f => f.NegotiatePrisonerExchange(payerId, captiveId), Times.Once);
+    }
+
+    [Fact]
+    public void TryResolveRansom_PayerRefuses_ExchangeSucceeds()
+    {
+        var payerId = Guid.NewGuid();
+        var captiveId = Guid.NewGuid();
+        const int amount = 100;
+
+        var funds = new Mock<ICharacterFundsService>();
+        var decision = new Mock<IRansomDecisionService>();
+        var factions = new Mock<IFactionService>();
+        decision.Setup(d => d.WillPayRansom(payerId, captiveId, amount)).Returns(false);
+        factions.Setup(f => f.NegotiatePrisonerExchange(payerId, captiveId)).Returns(true);
+
+        var service = new RansomService(
+            Mock.Of<ICharacterRepository>(),
+            funds.Object,
+            Mock.Of<IFactionFundsRepository>(),
+            Mock.Of<IPlanetRepository>(),
+            Mock.Of<IFleetRepository>(),
+            decision.Object,
+            factions.Object);
+
+        var result = service.TryResolveRansom(payerId, captiveId, amount);
+
+        result.Should().BeTrue();
+        funds.Verify(f => f.DeductCharacter(It.IsAny<Guid>(), It.IsAny<int>()), Times.Never);
+        factions.Verify(f => f.NegotiatePrisonerExchange(payerId, captiveId), Times.Once);
     }
 }


### PR DESCRIPTION
## Summary
- Add prisoner exchange negotiation to `IFactionService` and implement standing adjustments
- Integrate `RansomService` with faction exchanges before failing payments
- Cover goodwill and hostility outcomes with unit tests

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68ad6f2eee388321b3dd70eb4b3610a9