### PR TITLE
Add ransom marketplace service

### DIFF
--- a/Domain/Services/IRansomMarketplaceService.cs
+++ b/Domain/Services/IRansomMarketplaceService.cs
@@ -1,0 +1,37 @@
+using System;
+using System.Collections.Generic;
+
+namespace SkyHorizont.Domain.Services
+{
+    /// <summary>
+    /// Represents a listing of an unpaid captive and the demanded ransom.
+    /// </summary>
+    public record RansomListing(Guid CaptiveId, Guid CaptorId, int Amount, bool CaptorIsFaction);
+
+    /// <summary>
+    /// Provides a marketplace interface for browsing and purchasing ransom listings.
+    /// </summary>
+    public interface IRansomMarketplaceService
+    {
+        /// <summary>
+        /// Returns all current ransom listings.
+        /// </summary>
+        IEnumerable<RansomListing> GetListings();
+
+        /// <summary>
+        /// Adds a new listing to the marketplace.
+        /// </summary>
+        void AddListing(RansomListing listing);
+
+        /// <summary>
+        /// Attempts to purchase a ransom as an individual character.
+        /// </summary>
+        bool TryPurchaseAsCharacter(Guid buyerId, Guid captiveId);
+
+        /// <summary>
+        /// Attempts to purchase a ransom as a faction.
+        /// </summary>
+        bool TryPurchaseAsFaction(Guid factionId, Guid captiveId);
+    }
+}
+

--- a/Infrastructure/DomainServices/RansomMarketplaceService.cs
+++ b/Infrastructure/DomainServices/RansomMarketplaceService.cs
@@ -1,0 +1,68 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using SkyHorizont.Domain.Factions;
+using SkyHorizont.Domain.Services;
+
+namespace SkyHorizont.Infrastructure.DomainServices
+{
+    /// <summary>
+    /// In-memory implementation of <see cref="IRansomMarketplaceService"/>.
+    /// Allows browsing and purchasing ransom listings.
+    /// </summary>
+    public class RansomMarketplaceService : IRansomMarketplaceService
+    {
+        private readonly ICharacterFundsService _characterFunds;
+        private readonly IFactionFundsRepository _factionFunds;
+        private readonly List<RansomListing> _listings = new();
+
+        public RansomMarketplaceService(
+            ICharacterFundsService characterFunds,
+            IFactionFundsRepository factionFunds)
+        {
+            _characterFunds = characterFunds;
+            _factionFunds = factionFunds;
+        }
+
+        public IEnumerable<RansomListing> GetListings() => _listings.AsReadOnly();
+
+        public void AddListing(RansomListing listing) => _listings.Add(listing);
+
+        public bool TryPurchaseAsCharacter(Guid buyerId, Guid captiveId)
+        {
+            var listing = _listings.FirstOrDefault(l => l.CaptiveId == captiveId);
+            if (listing == null)
+                return false;
+            if (!_characterFunds.DeductCharacter(buyerId, listing.Amount))
+                return false;
+
+            CreditCaptor(listing);
+            _listings.Remove(listing);
+            return true;
+        }
+
+        public bool TryPurchaseAsFaction(Guid factionId, Guid captiveId)
+        {
+            var listing = _listings.FirstOrDefault(l => l.CaptiveId == captiveId);
+            if (listing == null)
+                return false;
+
+            if (_factionFunds.GetBalance(factionId) < listing.Amount)
+                return false;
+
+            _factionFunds.DeductBalance(factionId, listing.Amount);
+            CreditCaptor(listing);
+            _listings.Remove(listing);
+            return true;
+        }
+
+        private void CreditCaptor(RansomListing listing)
+        {
+            if (listing.CaptorIsFaction)
+                _factionFunds.AddBalance(listing.CaptorId, listing.Amount);
+            else
+                _characterFunds.CreditCharacter(listing.CaptorId, listing.Amount);
+        }
+    }
+}
+

--- a/Tests/Infrastructure/RansomMarketplaceServiceTests.cs
+++ b/Tests/Infrastructure/RansomMarketplaceServiceTests.cs
@@ -1,0 +1,73 @@
+using System;
+using FluentAssertions;
+using Moq;
+using SkyHorizont.Domain.Factions;
+using SkyHorizont.Domain.Services;
+using SkyHorizont.Infrastructure.DomainServices;
+using Xunit;
+
+namespace SkyHorizont.Tests.Infrastructure;
+
+public class RansomMarketplaceServiceTests
+{
+    [Fact]
+    public void GetListings_ReturnsAddedListings()
+    {
+        var service = new RansomMarketplaceService(
+            Mock.Of<ICharacterFundsService>(),
+            Mock.Of<IFactionFundsRepository>());
+
+        var listing = new RansomListing(Guid.NewGuid(), Guid.NewGuid(), 100, false);
+        service.AddListing(listing);
+
+        service.GetListings().Should().ContainSingle(l => l == listing);
+    }
+
+    [Fact]
+    public void TryPurchaseAsCharacter_DeductsAndCredits()
+    {
+        var captive = Guid.NewGuid();
+        var captor = Guid.NewGuid();
+        var rescuer = Guid.NewGuid();
+        const int amount = 200;
+
+        var funds = new Mock<ICharacterFundsService>();
+        funds.Setup(f => f.DeductCharacter(rescuer, amount)).Returns(true);
+
+        var factionFunds = new Mock<IFactionFundsRepository>();
+
+        var service = new RansomMarketplaceService(funds.Object, factionFunds.Object);
+        service.AddListing(new RansomListing(captive, captor, amount, false));
+
+        var result = service.TryPurchaseAsCharacter(rescuer, captive);
+
+        result.Should().BeTrue();
+        funds.Verify(f => f.DeductCharacter(rescuer, amount), Times.Once);
+        funds.Verify(f => f.CreditCharacter(captor, amount), Times.Once);
+        service.GetListings().Should().BeEmpty();
+    }
+
+    [Fact]
+    public void TryPurchaseAsFaction_DeductsAndCredits()
+    {
+        var captive = Guid.NewGuid();
+        var captorFaction = Guid.NewGuid();
+        var rescuerFaction = Guid.NewGuid();
+        const int amount = 150;
+
+        var funds = new Mock<ICharacterFundsService>();
+        var factionFunds = new Mock<IFactionFundsRepository>();
+        factionFunds.Setup(f => f.GetBalance(rescuerFaction)).Returns(amount);
+
+        var service = new RansomMarketplaceService(funds.Object, factionFunds.Object);
+        service.AddListing(new RansomListing(captive, captorFaction, amount, true));
+
+        var result = service.TryPurchaseAsFaction(rescuerFaction, captive);
+
+        result.Should().BeTrue();
+        factionFunds.Verify(f => f.DeductBalance(rescuerFaction, amount), Times.Once);
+        factionFunds.Verify(f => f.AddBalance(captorFaction, amount), Times.Once);
+        service.GetListings().Should().BeEmpty();
+    }
+}
+


### PR DESCRIPTION
## Summary
- add a ransom marketplace domain interface
- implement ransom marketplace service for characters and factions
- test marketplace operations

## Testing
- `dotnet test`


------
https://chatgpt.com/codex/tasks/task_e_68ad6f2c99cc8321bbdcc2fd5d9ff250