### PR TITLE
Implement ransom payer discovery

### DIFF
--- a/Domain/Entity/ICharacterRepository.cs
+++ b/Domain/Entity/ICharacterRepository.cs
@@ -13,5 +13,9 @@ namespace SkyHorizont.Domain.Entity
         /// character, such as friends, rivals or lovers.
         /// </summary>
         IEnumerable<Character> GetAssociates(Guid characterId);
+        /// <summary>
+        /// Returns all family members linked to the specified character.
+        /// </summary>
+        IEnumerable<Character> GetFamilyMembers(Guid characterId);
     }
 }

--- a/Domain/Services/IRansomService.cs
+++ b/Domain/Services/IRansomService.cs
@@ -8,13 +8,14 @@ namespace SkyHorizont.Domain.Services
         /// <summary>
         /// Attempts to settle a ransom for the specified captive.
         /// The service will search for willing payers among family members,
-        /// faction mates and other associates, charging the first candidate
+        /// rivals, faction mates and secret lovers, charging the first candidate
         /// that both agrees and has sufficient funds.
         /// </summary>
         /// <param name="captiveId">Captive to receive the funds.</param>
         /// <param name="amount">Ransom amount.</param>
+        /// <param name="captorId">Identifier of the captor character.</param>
         /// <returns>true if payment succeeded; otherwise false.</returns>
-        bool TryResolveRansom(Guid payerId, Guid captiveId, int amount);
+        bool TryResolveRansom(Guid captiveId, int amount, Guid captorId);
 
         /// <summary>
         /// Handles a captive whose ransom was not paid in time, determining their fate.

--- a/Infrastructure/DomainServices/RansomService.cs
+++ b/Infrastructure/DomainServices/RansomService.cs
@@ -1,6 +1,8 @@
 using SkyHorizont.Domain.Entity;
 using SkyHorizont.Domain.Factions;
 using SkyHorizont.Domain.Services;
+using System.Collections.Generic;
+using System.Linq;
 
 namespace SkyHorizont.Infrastructure.DomainServices
 {
@@ -13,6 +15,7 @@ namespace SkyHorizont.Infrastructure.DomainServices
         private readonly ICharacterFundsService _funds;
         private readonly IRansomDecisionService _decision;
         private readonly IFactionService _factions;
+        private readonly IFactionFundsRepository _factionFunds;
         private readonly IRandomService _rng;
         private readonly IRansomMarketplaceService _market;
 
@@ -21,6 +24,7 @@ namespace SkyHorizont.Infrastructure.DomainServices
             ICharacterFundsService characterFundsService,
             IRansomDecisionService decisionService,
             IFactionService factions,
+            IFactionFundsRepository factionFunds,
             IRandomService rng,
             IRansomMarketplaceService market)
         {
@@ -28,24 +32,64 @@ namespace SkyHorizont.Infrastructure.DomainServices
             _funds = characterFundsService;
             _decision = decisionService;
             _factions = factions;
+            _factionFunds = factionFunds;
             _rng = rng;
             _market = market;
         }
 
         /// <summary>
         /// Attempts to settle a ransom for the specified captive. Potential payers are
-        /// considered in order: family members, faction members and then other
-        /// associates (friends, rivals, lovers). For each candidate the decision
-        /// service is consulted before attempting to deduct funds.
+        /// considered in order: family members, rival characters, faction members
+        /// and secret lovers. For each candidate the decision service is consulted
+        /// before attempting to deduct funds from either personal or faction treasuries.
         /// </summary>
-        public bool TryResolveRansom(Guid payerId, Guid captiveId, int amount)
+        public bool TryResolveRansom(Guid captiveId, int amount, Guid captorId)
         {
-            if (!_decision.WillPayRansom(payerId, captiveId, amount))
-                return _factions.NegotiatePrisonerExchange(payerId, captiveId);
-            if (!_funds.DeductCharacter(payerId, amount))
-                return _factions.NegotiatePrisonerExchange(payerId, captiveId);
-            _funds.CreditCharacter(captiveId, amount);
-            return true;
+            var captive = _cmdRepo.GetById(captiveId);
+            if (captive == null)
+                return false;
+
+            var candidates = new List<Guid>();
+
+            // Family members first
+            candidates.AddRange(_cmdRepo.GetFamilyMembers(captiveId).Select(c => c.Id));
+
+            // Rivals
+            candidates.AddRange(captive.Relationships
+                .Where(r => r.Type == RelationshipType.Rival)
+                .Select(r => r.TargetCharacterId));
+
+            // Faction members
+            var factionId = _factions.GetFactionIdForCharacter(captiveId);
+            var faction = _factions.GetFaction(factionId);
+            candidates.AddRange(faction.CharacterIds.Where(id => id != captiveId));
+
+            // Secret lovers
+            candidates.AddRange(captive.Relationships
+                .Where(r => r.Type == RelationshipType.Lover)
+                .Select(r => r.TargetCharacterId));
+
+            foreach (var payerId in candidates.Distinct())
+            {
+                if (!_decision.WillPayRansom(payerId, captiveId, amount))
+                    continue;
+
+                if (_funds.DeductCharacter(payerId, amount))
+                {
+                    _funds.CreditCharacter(captiveId, amount);
+                    return true;
+                }
+
+                var payerFaction = _factions.GetFactionIdForCharacter(payerId);
+                if (_factionFunds.GetBalance(payerFaction) >= amount)
+                {
+                    _factionFunds.AddBalance(payerFaction, -amount);
+                    _funds.CreditCharacter(captiveId, amount);
+                    return true;
+                }
+            }
+
+            return false;
         }
 
         public void HandleUnpaidRansom(Guid captiveId, Guid captorFaction)

--- a/Infrastructure/Persistence/Repositories/CharactersRepository.cs
+++ b/Infrastructure/Persistence/Repositories/CharactersRepository.cs
@@ -64,5 +64,14 @@ namespace SkyHorizont.Infrastructure.Persistence
 
             return GetByIds(associateIds);
         }
+
+        public IEnumerable<Character> GetFamilyMembers(Guid characterId)
+        {
+            var character = GetById(characterId);
+            if (character == null)
+                return Enumerable.Empty<Character>();
+
+            return GetByIds(character.FamilyLinkIds);
+        }
     }
 }

--- a/Tests/Infrastructure/RansomServiceTests.cs
+++ b/Tests/Infrastructure/RansomServiceTests.cs
@@ -1,9 +1,8 @@
+using System;
 using FluentAssertions;
 using Moq;
 using SkyHorizont.Domain.Entity;
 using SkyHorizont.Domain.Factions;
-using SkyHorizont.Domain.Galaxy.Planet;
-using SkyHorizont.Domain.Fleets;
 using SkyHorizont.Domain.Services;
 using SkyHorizont.Infrastructure.DomainServices;
 using SkyHorizont.Infrastructure.Testing;
@@ -19,103 +18,70 @@ public class RansomServiceTests
             new SkillSet(0, 0, 0, 0));
 
     [Fact]
-    public void TryResolveRansom_PayerRefuses_ExchangeFails_DoesNotDeductFunds()
-
+    public void TryResolveRansom_FamilyMemberPays()
     {
         var captiveId = Guid.NewGuid();
-        var associateId = Guid.NewGuid();
+        var familyId = Guid.NewGuid();
         const int amount = 100;
 
+        var captive = CreateCharacter(captiveId, "Captive");
+        var familyMember = CreateCharacter(familyId, "Kin");
+
+        var repo = new Mock<ICharacterRepository>();
+        repo.Setup(r => r.GetById(captiveId)).Returns(captive);
+        repo.Setup(r => r.GetFamilyMembers(captiveId)).Returns(new[] { familyMember });
+
+        var funds = new Mock<ICharacterFundsService>();
+        funds.Setup(f => f.DeductCharacter(familyId, amount)).Returns(true);
+
+        var decision = new Mock<IRansomDecisionService>();
+        decision.Setup(d => d.WillPayRansom(familyId, captiveId, amount)).Returns(true);
+
+        var factionSvc = new Mock<IFactionService>();
+        var faction = new Faction(Guid.NewGuid(), "f", Guid.NewGuid());
+        factionSvc.Setup(f => f.GetFactionIdForCharacter(It.IsAny<Guid>())).Returns(Guid.NewGuid());
+        factionSvc.Setup(f => f.GetFaction(It.IsAny<Guid>())).Returns(faction);
+
+        var factionFunds = new Mock<IFactionFundsRepository>();
+        var service = new RansomService(repo.Object, funds.Object, decision.Object,
+            factionSvc.Object, factionFunds.Object, Mock.Of<IRandomService>(), Mock.Of<IRansomMarketplaceService>());
+
+        var result = service.TryResolveRansom(captiveId, amount, Guid.NewGuid());
+
+        result.Should().BeTrue();
+        funds.Verify(f => f.DeductCharacter(familyId, amount), Times.Once);
+        funds.Verify(f => f.CreditCharacter(captiveId, amount), Times.Once);
+    }
+
+    [Fact]
+    public void TryResolveRansom_NoCandidatePays_ReturnsFalse()
+    {
+        var captiveId = Guid.NewGuid();
+        const int amount = 100;
         var captive = CreateCharacter(captiveId, "Captive");
 
         var repo = new Mock<ICharacterRepository>();
         repo.Setup(r => r.GetById(captiveId)).Returns(captive);
-        repo.Setup(r => r.GetAssociates(captiveId))
-            .Returns(new[] { CreateCharacter(associateId, "Assoc") });
+        repo.Setup(r => r.GetFamilyMembers(captiveId)).Returns(Array.Empty<Character>());
 
         var funds = new Mock<ICharacterFundsService>();
         var decision = new Mock<IRansomDecisionService>();
 
-        var factions = new Mock<IFactionService>();
-        decision.Setup(d => d.WillPayRansom(payerId, captiveId, amount)).Returns(false);
-        factions.Setup(f => f.NegotiatePrisonerExchange(payerId, captiveId)).Returns(false);
+        var factionSvc = new Mock<IFactionService>();
+        var faction = new Faction(Guid.NewGuid(), "f", Guid.NewGuid());
+        factionSvc.Setup(f => f.GetFactionIdForCharacter(It.IsAny<Guid>())).Returns(Guid.NewGuid());
+        factionSvc.Setup(f => f.GetFaction(It.IsAny<Guid>())).Returns(faction);
 
-        var service = new RansomService(
-            Mock.Of<ICharacterRepository>(),
-            funds.Object,
-            Mock.Of<IFactionFundsRepository>(),
-            Mock.Of<IPlanetRepository>(),
-            Mock.Of<IFleetRepository>(),
-            decision.Object,
-            factions.Object);
+        var factionFunds = new Mock<IFactionFundsRepository>();
 
-        var result = service.TryResolveRansom(captiveId, amount);
+        var service = new RansomService(repo.Object, funds.Object, decision.Object,
+            factionSvc.Object, factionFunds.Object, Mock.Of<IRandomService>(), Mock.Of<IRansomMarketplaceService>());
+
+        var result = service.TryResolveRansom(captiveId, amount, Guid.NewGuid());
 
         result.Should().BeFalse();
         funds.Verify(f => f.DeductCharacter(It.IsAny<Guid>(), It.IsAny<int>()), Times.Never);
-        factions.Verify(f => f.NegotiatePrisonerExchange(payerId, captiveId), Times.Once);
-    }
-
-    [Fact]
-    public void TryResolveRansom_PayerRefuses_ExchangeSucceeds()
-    {
-        var payerId = Guid.NewGuid();
-        var captiveId = Guid.NewGuid();
-        const int amount = 100;
-
-        var funds = new Mock<ICharacterFundsService>();
-        var decision = new Mock<IRansomDecisionService>();
-        var factions = new Mock<IFactionService>();
-        decision.Setup(d => d.WillPayRansom(payerId, captiveId, amount)).Returns(false);
-        factions.Setup(f => f.NegotiatePrisonerExchange(payerId, captiveId)).Returns(true);
-
-        var service = new RansomService(
-            Mock.Of<ICharacterRepository>(),
-            funds.Object,
-            Mock.Of<IFactionFundsRepository>(),
-            Mock.Of<IPlanetRepository>(),
-            Mock.Of<IFleetRepository>(),
-            decision.Object,
-            Mock.Of<IFactionService>(),
-            Mock.Of<IRandomService>());
-            factions.Object);
-
-        var result = service.TryResolveRansom(payerId, captiveId, amount);
-
-        result.Should().BeTrue();
-        funds.Verify(f => f.DeductCharacter(It.IsAny<Guid>(), It.IsAny<int>()), Times.Never);
-        factions.Verify(f => f.NegotiatePrisonerExchange(payerId, captiveId), Times.Once);
-    }
-
-    [Fact]
-    public void TryResolveRansom_AssociatePays_WhenWilling()
-    {
-        var captiveId = Guid.NewGuid();
-        var associateId = Guid.NewGuid();
-        const int amount = 200;
-
-        var captive = CreateCharacter(captiveId, "Captive");
-        var associate = CreateCharacter(associateId, "Friend");
-
-        var repo = new Mock<ICharacterRepository>();
-        repo.Setup(r => r.GetById(captiveId)).Returns(captive);
-        repo.Setup(r => r.GetAssociates(captiveId)).Returns(new[] { associate });
-
-        var funds = new Mock<ICharacterFundsService>();
-        funds.Setup(f => f.DeductCharacter(associateId, amount)).Returns(true);
-
-        var decision = new Mock<IRansomDecisionService>();
-        decision.Setup(d => d.WillPayRansom(associateId, captiveId, amount)).Returns(true);
-
-        var service = new RansomService(repo.Object, funds.Object,
-            Mock.Of<IFactionFundsRepository>(), Mock.Of<IPlanetRepository>(),
-            Mock.Of<IFleetRepository>(), decision.Object);
-
-        var result = service.TryResolveRansom(captiveId, amount);
-
-        result.Should().BeTrue();
-        funds.Verify(f => f.DeductCharacter(associateId, amount), Times.Once);
-        funds.Verify(f => f.CreditCharacter(captiveId, amount), Times.Once);
+        factionFunds.Verify(f => f.AddBalance(It.IsAny<Guid>(), It.IsAny<int>()), Times.Never);
     }
 
     [Fact]
@@ -130,15 +96,10 @@ public class RansomServiceTests
         var rng = new Mock<IRandomService>();
         rng.Setup(r => r.NextInt(0, 3)).Returns(0);
 
-        var service = new RansomService(
-            repo.Object,
-            Mock.Of<ICharacterFundsService>(),
-            Mock.Of<IFactionFundsRepository>(),
-            Mock.Of<IPlanetRepository>(),
-            Mock.Of<IFleetRepository>(),
-            Mock.Of<IRansomDecisionService>(),
-            Mock.Of<IFactionService>(),
-            rng.Object);
+        var factionSvc = new Mock<IFactionService>();
+        var service = new RansomService(repo.Object, Mock.Of<ICharacterFundsService>(),
+            Mock.Of<IRansomDecisionService>(), factionSvc.Object, Mock.Of<IFactionFundsRepository>(),
+            rng.Object, Mock.Of<IRansomMarketplaceService>());
 
         service.HandleUnpaidRansom(captiveId, captorFaction);
 
@@ -162,15 +123,9 @@ public class RansomServiceTests
         var factionSvc = new Mock<IFactionService>();
         factionSvc.Setup(f => f.GetLeaderId(captorFaction)).Returns(leaderId);
 
-        var service = new RansomService(
-            repo.Object,
-            Mock.Of<ICharacterFundsService>(),
-            Mock.Of<IFactionFundsRepository>(),
-            Mock.Of<IPlanetRepository>(),
-            Mock.Of<IFleetRepository>(),
-            Mock.Of<IRansomDecisionService>(),
-            factionSvc.Object,
-            rng.Object);
+        var service = new RansomService(repo.Object, Mock.Of<ICharacterFundsService>(),
+            Mock.Of<IRansomDecisionService>(), factionSvc.Object, Mock.Of<IFactionFundsRepository>(),
+            rng.Object, Mock.Of<IRansomMarketplaceService>());
 
         service.HandleUnpaidRansom(captiveId, captorFaction);
 
@@ -191,15 +146,10 @@ public class RansomServiceTests
         var rng = new Mock<IRandomService>();
         rng.Setup(r => r.NextInt(0, 3)).Returns(2);
 
-        var service = new RansomService(
-            repo.Object,
-            Mock.Of<ICharacterFundsService>(),
-            Mock.Of<IFactionFundsRepository>(),
-            Mock.Of<IPlanetRepository>(),
-            Mock.Of<IFleetRepository>(),
-            Mock.Of<IRansomDecisionService>(),
-            Mock.Of<IFactionService>(),
-            rng.Object);
+        var factionSvc = new Mock<IFactionService>();
+        var service = new RansomService(repo.Object, Mock.Of<ICharacterFundsService>(),
+            Mock.Of<IRansomDecisionService>(), factionSvc.Object, Mock.Of<IFactionFundsRepository>(),
+            rng.Object, Mock.Of<IRansomMarketplaceService>());
 
         service.HandleUnpaidRansom(captiveId, captorFaction);
 
@@ -207,4 +157,3 @@ public class RansomServiceTests
         captive.IsEnslaved.Should().BeFalse();
     }
 }
-


### PR DESCRIPTION
## Summary
- expand `ICharacterRepository` with `GetFamilyMembers`
- update `RansomService` to seek ransom payers (family, rivals, faction mates, lovers) and use faction funds
- adjust `IRansomService` signature and provide tests for new logic

## Testing
- `dotnet test` *(fails: command not found)*
- `apt-get install -y dotnet-sdk-7.0` *(fails: Unable to locate package)*

------
https://chatgpt.com/codex/tasks/task_e_68ad7f4828748321ba32be338fe52580