### PR TITLE
Reorder TryResolveRansom parameters and update flow

### DIFF
--- a/Domain/Services/IRansomService.cs
+++ b/Domain/Services/IRansomService.cs
@@ -7,15 +7,15 @@ namespace SkyHorizont.Domain.Services
     {
         /// <summary>
         /// Attempts to settle a ransom for the specified captive.
-        /// The service will search for willing payers among family members,
+        /// The service searches for willing payers among family members,
         /// rivals, faction mates and secret lovers, charging the first candidate
-        /// that both agrees and has sufficient funds.
+        /// that both agrees and has sufficient funds and crediting the captor.
         /// </summary>
-        /// <param name="captiveId">Captive to receive the funds.</param>
+        /// <param name="captiveId">Identifier of the captive whose release is negotiated.</param>
+        /// <param name="captorId">Identifier of the captor character to receive payment.</param>
         /// <param name="amount">Ransom amount.</param>
-        /// <param name="captorId">Identifier of the captor character.</param>
         /// <returns>true if payment succeeded; otherwise false.</returns>
-        bool TryResolveRansom(Guid captiveId, int amount, Guid captorId);
+        bool TryResolveRansom(Guid captiveId, Guid captorId, int amount);
 
         /// <summary>
         /// Handles a captive whose ransom was not paid in time, determining their fate.

--- a/Infrastructure/DomainServices/RansomService.cs
+++ b/Infrastructure/DomainServices/RansomService.cs
@@ -42,8 +42,9 @@ namespace SkyHorizont.Infrastructure.DomainServices
         /// considered in order: family members, rival characters, faction members
         /// and secret lovers. For each candidate the decision service is consulted
         /// before attempting to deduct funds from either personal or faction treasuries.
+        /// When payment succeeds, the amount is credited to the captor.
         /// </summary>
-        public bool TryResolveRansom(Guid captiveId, int amount, Guid captorId)
+        public bool TryResolveRansom(Guid captiveId, Guid captorId, int amount)
         {
             var captive = _cmdRepo.GetById(captiveId);
             if (captive == null)
@@ -76,7 +77,7 @@ namespace SkyHorizont.Infrastructure.DomainServices
 
                 if (_funds.DeductCharacter(payerId, amount))
                 {
-                    _funds.CreditCharacter(captiveId, amount);
+                    _funds.CreditCharacter(captorId, amount);
                     return true;
                 }
 
@@ -84,7 +85,7 @@ namespace SkyHorizont.Infrastructure.DomainServices
                 if (_factionFunds.GetBalance(payerFaction) >= amount)
                 {
                     _factionFunds.AddBalance(payerFaction, -amount);
-                    _funds.CreditCharacter(captiveId, amount);
+                    _funds.CreditCharacter(captorId, amount);
                     return true;
                 }
             }

--- a/Tests/Infrastructure/RansomServiceTests.cs
+++ b/Tests/Infrastructure/RansomServiceTests.cs
@@ -22,6 +22,7 @@ public class RansomServiceTests
     {
         var captiveId = Guid.NewGuid();
         var familyId = Guid.NewGuid();
+        var captorId = Guid.NewGuid();
         const int amount = 100;
 
         var captive = CreateCharacter(captiveId, "Captive");
@@ -46,11 +47,11 @@ public class RansomServiceTests
         var service = new RansomService(repo.Object, funds.Object, decision.Object,
             factionSvc.Object, factionFunds.Object, Mock.Of<IRandomService>(), Mock.Of<IRansomMarketplaceService>());
 
-        var result = service.TryResolveRansom(captiveId, amount, Guid.NewGuid());
+        var result = service.TryResolveRansom(captiveId, captorId, amount);
 
         result.Should().BeTrue();
         funds.Verify(f => f.DeductCharacter(familyId, amount), Times.Once);
-        funds.Verify(f => f.CreditCharacter(captiveId, amount), Times.Once);
+        funds.Verify(f => f.CreditCharacter(captorId, amount), Times.Once);
     }
 
     [Fact]
@@ -77,7 +78,7 @@ public class RansomServiceTests
         var service = new RansomService(repo.Object, funds.Object, decision.Object,
             factionSvc.Object, factionFunds.Object, Mock.Of<IRandomService>(), Mock.Of<IRansomMarketplaceService>());
 
-        var result = service.TryResolveRansom(captiveId, amount, Guid.NewGuid());
+        var result = service.TryResolveRansom(captiveId, Guid.NewGuid(), amount);
 
         result.Should().BeFalse();
         funds.Verify(f => f.DeductCharacter(It.IsAny<Guid>(), It.IsAny<int>()), Times.Never);


### PR DESCRIPTION
## Summary
- Reorder `TryResolveRansom` method signature to `(Guid captiveId, Guid captorId, int amount)` and clarify captor payment in docs
- Update ransom resolution service to credit the captor when payment succeeds
- Adjust tests to use the new parameter order and verify captor receives funds

## Testing
- `dotnet test`


------
https://chatgpt.com/codex/tasks/task_e_68ad8f31d22c8321b7b6d57848ad9eab