### PR TITLE
Add secret lover and family retrieval to character repository

### DIFF
--- a/Domain/Entity/ICharacterRepository.cs
+++ b/Domain/Entity/ICharacterRepository.cs
@@ -17,5 +17,9 @@ namespace SkyHorizont.Domain.Entity
         /// Returns all family members linked to the specified character.
         /// </summary>
         IEnumerable<Character> GetFamilyMembers(Guid characterId);
+        /// <summary>
+        /// Returns all secret lovers linked to the specified character.
+        /// </summary>
+        IEnumerable<Character> GetSecretLovers(Guid characterId);
     }
 }

--- a/Infrastructure/Persistence/Repositories/CharactersRepository.cs
+++ b/Infrastructure/Persistence/Repositories/CharactersRepository.cs
@@ -65,6 +65,19 @@ namespace SkyHorizont.Infrastructure.Persistence
             return GetByIds(associateIds);
         }
 
+        public IEnumerable<Character> GetSecretLovers(Guid characterId)
+        {
+            var character = GetById(characterId);
+            if (character == null)
+                return Enumerable.Empty<Character>();
+
+            var loverIds = character.Relationships
+                .Where(r => r.Type == RelationshipType.Lover)
+                .Select(r => r.TargetCharacterId);
+
+            return GetByIds(loverIds);
+        }
+
         public IEnumerable<Character> GetFamilyMembers(Guid characterId)
         {
             var character = GetById(characterId);

--- a/Tests/Infrastructure/CharactersRepositoryTests.cs
+++ b/Tests/Infrastructure/CharactersRepositoryTests.cs
@@ -1,0 +1,59 @@
+using System;
+using System.Linq;
+using FluentAssertions;
+using SkyHorizont.Domain.Entity;
+using SkyHorizont.Infrastructure.Persistence;
+using SkyHorizont.Infrastructure.Testing;
+using Xunit;
+
+namespace SkyHorizont.Tests.Infrastructure;
+
+public class CharactersRepositoryTests
+{
+    [Fact]
+    public void GetFamilyMembers_ReturnsLinkedFamily()
+    {
+        var ctx = new InMemoryCharactersDbContext();
+        var repo = new CharactersRepository(ctx);
+
+        var actor = CharacterFactory.CreateSuperPositive(Guid.NewGuid(), "Actor", Sex.Male, 30, 3000, 1);
+        var fam1 = CharacterFactory.CreateSuperPositive(Guid.NewGuid(), "Fam1", Sex.Female, 25, 3005, 5);
+        var fam2 = CharacterFactory.CreateSuperPositive(Guid.NewGuid(), "Fam2", Sex.Male, 20, 3005, 5);
+
+        actor.LinkFamilyMember(fam1.Id);
+        actor.LinkFamilyMember(fam2.Id);
+
+        ctx.Characters[actor.Id] = actor;
+        ctx.Characters[fam1.Id] = fam1;
+        ctx.Characters[fam2.Id] = fam2;
+
+        var family = repo.GetFamilyMembers(actor.Id).ToList();
+
+        family.Should().HaveCount(2).And.Contain(fam1).And.Contain(fam2);
+    }
+
+    [Fact]
+    public void GetSecretLovers_ExcludesSpouse()
+    {
+        var ctx = new InMemoryCharactersDbContext();
+        var repo = new CharactersRepository(ctx);
+
+        var actor = CharacterFactory.CreateSuperPositive(Guid.NewGuid(), "Actor", Sex.Male, 30, 3000, 1);
+        var lover = CharacterFactory.CreateSuperPositive(Guid.NewGuid(), "Lover", Sex.Female, 24, 3002, 3);
+        var spouse = CharacterFactory.CreateSuperPositive(Guid.NewGuid(), "Spouse", Sex.Female, 28, 2998, 7);
+
+        actor.AddRelationship(lover.Id, RelationshipType.Lover);
+        lover.AddRelationship(actor.Id, RelationshipType.Lover);
+
+        actor.AddRelationship(spouse.Id, RelationshipType.Spouse);
+        spouse.AddRelationship(actor.Id, RelationshipType.Spouse);
+
+        ctx.Characters[actor.Id] = actor;
+        ctx.Characters[lover.Id] = lover;
+        ctx.Characters[spouse.Id] = spouse;
+
+        var lovers = repo.GetSecretLovers(actor.Id).ToList();
+
+        lovers.Should().ContainSingle().Which.Should().Be(lover);
+    }
+}


### PR DESCRIPTION
## Summary
- expose retrieval for linked family members and secret lovers in the character repository
- cover family and secret lover lookups with unit tests

## Testing
- `dotnet test`

------
https://chatgpt.com/codex/tasks/task_e_68ad903825008321832dd3cbc7fcd0a0