### PR TITLE
feat: add multi-round ransom negotiations with pricing

### DIFF
--- a/Domain/Entity/CharacterRelationship.cs
+++ b/Domain/Entity/CharacterRelationship.cs
@@ -10,6 +10,7 @@ namespace SkyHorizont.Domain.Entity
         Partner,
         ExSpouse,
         Friend,
-        Rival
+        Rival,
+        HaremMember
     }
 }

--- a/Domain/Prisoners/PendingRansom.cs
+++ b/Domain/Prisoners/PendingRansom.cs
@@ -1,0 +1,40 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace SkyHorizont.Domain.Prisoners
+{
+    /// <summary>
+    /// Represents an ongoing ransom negotiation handled over multiple turns.
+    /// </summary>
+    public class PendingRansom
+    {
+        private readonly List<Guid> _candidates;
+
+        public Guid CaptiveId { get; }
+        public Guid CaptorId { get; }
+        public int Amount { get; }
+        public int NextIndex { get; private set; }
+        public IReadOnlyList<Guid> CandidatePayers => _candidates.AsReadOnly();
+
+        public PendingRansom(Guid captiveId, Guid captorId, int amount, IEnumerable<Guid> candidates)
+        {
+            CaptiveId = captiveId;
+            CaptorId = captorId;
+            Amount = amount;
+            _candidates = candidates.ToList();
+            NextIndex = 0;
+        }
+
+        /// <summary>
+        /// Returns the next candidate to ask for payment, or null if no more remain.
+        /// Advances the internal index when a candidate is returned.
+        /// </summary>
+        public Guid? NextPayer()
+        {
+            if (NextIndex >= _candidates.Count)
+                return null;
+            return _candidates[NextIndex++];
+        }
+    }
+}

--- a/Domain/Services/IRansomPricingService.cs
+++ b/Domain/Services/IRansomPricingService.cs
@@ -1,0 +1,15 @@
+using System;
+
+namespace SkyHorizont.Domain.Services
+{
+    /// <summary>
+    /// Provides dynamic ransom price estimates based on character status.
+    /// </summary>
+    public interface IRansomPricingService
+    {
+        /// <summary>
+        /// Estimates the ransom value for the specified captive.
+        /// </summary>
+        int EstimateRansomValue(Guid captiveId);
+    }
+}

--- a/Domain/Services/IRansomService.cs
+++ b/Domain/Services/IRansomService.cs
@@ -6,27 +6,28 @@ namespace SkyHorizont.Domain.Services
     public interface IRansomService
     {
         /// <summary>
-        /// Attempts to settle a ransom for the specified captive.
-        /// The service searches for willing payers among family members,
-        /// rivals, faction mates and secret lovers, charging the first candidate
-        /// that both agrees and has sufficient funds and crediting the captor.
+        /// Starts a ransom negotiation for the captive. The amount is calculated
+        /// by the pricing service and candidate payers are recorded.
         /// </summary>
-        /// <param name="captiveId">Identifier of the captive whose release is negotiated.</param>
-        /// <param name="captorId">Identifier of the captor character to receive payment.</param>
-        /// <param name="amount">Ransom amount.</param>
-        /// <returns>true if payment succeeded; otherwise false.</returns>
-        bool TryResolveRansom(Guid captiveId, Guid captorId, int amount);
+        void StartRansom(Guid captiveId, Guid captorId);
+
+        /// <summary>
+        /// Processes a single negotiation turn for the captive. Exactly one
+        /// candidate payer is approached per call. Returns true if the ransom
+        /// remains pending after this call; false if negotiation concluded
+        /// either by payment or by exhausting all candidates.
+        /// </summary>
+        bool ProcessRansomTurn(Guid captiveId);
 
         /// <summary>
         /// Handles a captive whose ransom was not paid in time by listing them on the
         /// ransom marketplace.
         /// </summary>
-        /// <param name="captiveId">Identifier of the captive being listed.</param>
-        /// <param name="captorId">Identifier of the captor (character or faction).
-        /// This entity will receive payment when the ransom is purchased.</param>
-        /// <param name="amount">Ransom amount to demand for the captive.</param>
-        /// <param name="captorIsFaction">True if the captor identifier refers to a faction;
-        /// otherwise it refers to an individual character.</param>
         void HandleUnpaidRansom(Guid captiveId, Guid captorId, int amount, bool captorIsFaction);
+
+        /// <summary>
+        /// Converts the captive into a harem member of the captor, skipping ransom flow.
+        /// </summary>
+        void KeepInHarem(Guid captiveId, Guid captorId);
     }
 }

--- a/Infrastructure/DomainServices/RansomPricingService.cs
+++ b/Infrastructure/DomainServices/RansomPricingService.cs
@@ -1,0 +1,67 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using SkyHorizont.Domain.Entity;
+using SkyHorizont.Domain.Factions;
+using SkyHorizont.Domain.Services;
+
+namespace SkyHorizont.Infrastructure.DomainServices
+{
+    /// <summary>
+    /// Calculates ransom prices using rank, parentage and faction strength.
+    /// </summary>
+    public class RansomPricingService : IRansomPricingService
+    {
+        private readonly ICharacterRepository _characters;
+        private readonly IFactionService _factions;
+
+        private static readonly Dictionary<Rank, int> BaseValues = new()
+        {
+            { Rank.Civilian, 100 },
+            { Rank.Courtesan, 200 },
+            { Rank.Lieutenant, 400 },
+            { Rank.Captain, 800 },
+            { Rank.Major, 1600 },
+            { Rank.Colonel, 3200 },
+            { Rank.General, 6400 },
+            { Rank.Leader, 10000 }
+        };
+
+        public RansomPricingService(ICharacterRepository characters, IFactionService factions)
+        {
+            _characters = characters;
+            _factions = factions;
+        }
+
+        public int EstimateRansomValue(Guid captiveId)
+        {
+            var captive = _characters.GetById(captiveId);
+            if (captive == null)
+                return 0;
+
+            var baseValue = BaseValues.TryGetValue(captive.Rank, out var value) ? value : 100;
+
+            var parents = _characters.GetFamilyMembers(captiveId)
+                .Where(p => p.Age > captive.Age)
+                .Take(2)
+                .ToList();
+
+            double parentModifier = 1.0;
+            if (parents.Count > 0)
+            {
+                double sum = 0;
+                foreach (var parent in parents)
+                {
+                    sum += 1 + (int)parent.Rank * 0.1;
+                }
+                parentModifier = sum / parents.Count;
+            }
+
+            var factionId = _factions.GetFactionIdForCharacter(captiveId);
+            var strength = _factions.GetEconomicStrength(factionId);
+            double factionFactor = strength >= 1000 ? 2.0 : strength >= 500 ? 1.5 : 1.0;
+
+            return (int)(baseValue * parentModifier * factionFactor);
+        }
+    }
+}

--- a/Tests/Infrastructure/RansomMarketplaceServiceTests.cs
+++ b/Tests/Infrastructure/RansomMarketplaceServiceTests.cs
@@ -24,50 +24,57 @@ public class RansomMarketplaceServiceTests
     }
 
     [Fact]
-    public void TryPurchaseAsCharacter_DeductsAndCredits()
+    public void TryPurchaseAsCharacter_DeductsAndCreditsWithFee()
     {
         var captive = Guid.NewGuid();
         var captor = Guid.NewGuid();
         var rescuer = Guid.NewGuid();
         const int amount = 200;
+        const double feeRate = 0.1;
+        var feeRecipient = Guid.NewGuid();
+        var expectedNet = amount - (int)(amount * feeRate);
 
         var funds = new Mock<ICharacterFundsService>();
         funds.Setup(f => f.DeductCharacter(rescuer, amount)).Returns(true);
 
         var factionFunds = new Mock<IFactionFundsRepository>();
 
-        var service = new RansomMarketplaceService(funds.Object, factionFunds.Object);
+        var service = new RansomMarketplaceService(funds.Object, factionFunds.Object, feeRate, feeRecipient);
         service.AddListing(new RansomListing(captive, captor, amount, false));
 
         var result = service.TryPurchaseAsCharacter(rescuer, captive);
 
         result.Should().BeTrue();
         funds.Verify(f => f.DeductCharacter(rescuer, amount), Times.Once);
-        funds.Verify(f => f.CreditCharacter(captor, amount), Times.Once);
+        funds.Verify(f => f.CreditCharacter(captor, expectedNet), Times.Once);
+        factionFunds.Verify(f => f.AddBalance(feeRecipient, amount - expectedNet), Times.Once);
         service.GetListings().Should().BeEmpty();
     }
 
     [Fact]
-    public void TryPurchaseAsFaction_DeductsAndCredits()
+    public void TryPurchaseAsFaction_DeductsAndCreditsWithFee()
     {
         var captive = Guid.NewGuid();
         var captorFaction = Guid.NewGuid();
         var rescuerFaction = Guid.NewGuid();
         const int amount = 150;
+        const double feeRate = 0.1;
+        var feeRecipient = Guid.NewGuid();
+        var expectedNet = amount - (int)(amount * feeRate);
 
         var funds = new Mock<ICharacterFundsService>();
         var factionFunds = new Mock<IFactionFundsRepository>();
         factionFunds.Setup(f => f.GetBalance(rescuerFaction)).Returns(amount);
 
-        var service = new RansomMarketplaceService(funds.Object, factionFunds.Object);
+        var service = new RansomMarketplaceService(funds.Object, factionFunds.Object, feeRate, feeRecipient);
         service.AddListing(new RansomListing(captive, captorFaction, amount, true));
 
         var result = service.TryPurchaseAsFaction(rescuerFaction, captive);
 
         result.Should().BeTrue();
         factionFunds.Verify(f => f.DeductBalance(rescuerFaction, amount), Times.Once);
-        factionFunds.Verify(f => f.AddBalance(captorFaction, amount), Times.Once);
+        factionFunds.Verify(f => f.AddBalance(captorFaction, expectedNet), Times.Once);
+        factionFunds.Verify(f => f.AddBalance(feeRecipient, amount - expectedNet), Times.Once);
         service.GetListings().Should().BeEmpty();
     }
 }
-

--- a/Tests/Infrastructure/RansomPricingServiceTests.cs
+++ b/Tests/Infrastructure/RansomPricingServiceTests.cs
@@ -1,0 +1,42 @@
+using System;
+using FluentAssertions;
+using Moq;
+using SkyHorizont.Domain.Entity;
+using SkyHorizont.Domain.Factions;
+using SkyHorizont.Domain.Services;
+using SkyHorizont.Infrastructure.DomainServices;
+using SkyHorizont.Infrastructure.Testing;
+using Xunit;
+
+namespace SkyHorizont.Tests.Infrastructure;
+
+public class RansomPricingServiceTests
+{
+    [Fact]
+    public void EstimateRansomValue_ConsidersRankParentsAndFaction()
+    {
+        var captiveId = Guid.NewGuid();
+        var factionId = Guid.NewGuid();
+        var captive = CharacterFactory.CreateSuperPositive(captiveId, "Cap", Sex.Male, 20, 2000, 1, Rank.Captain);
+        var mother = CharacterFactory.CreateSuperPositive(Guid.NewGuid(), "Mom", Sex.Female, 40, 1980, 1, Rank.General);
+        var father = CharacterFactory.CreateSuperPositive(Guid.NewGuid(), "Dad", Sex.Male, 42, 1978, 1, Rank.Colonel);
+
+        mother.AddRelationship(father.Id, RelationshipType.Spouse);
+        father.AddRelationship(mother.Id, RelationshipType.Spouse);
+
+        var repo = new Mock<ICharacterRepository>();
+        repo.Setup(r => r.GetById(captiveId)).Returns(captive);
+        repo.Setup(r => r.GetFamilyMembers(captiveId)).Returns(new[] { mother, father });
+
+        var factions = new Mock<IFactionService>();
+        factions.Setup(f => f.GetFactionIdForCharacter(captiveId)).Returns(factionId);
+        factions.Setup(f => f.GetEconomicStrength(factionId)).Returns(1000);
+
+        var service = new RansomPricingService(repo.Object, factions.Object);
+
+        var price = service.EstimateRansomValue(captiveId);
+
+        // base 800 * parent modifier (>1) * faction factor (2.0)
+        price.Should().BeGreaterThan(800);
+    }
+}

--- a/Web/ServiceCollectionExtensions.cs
+++ b/Web/ServiceCollectionExtensions.cs
@@ -88,6 +88,7 @@ namespace SkyHorizont.Infrastructure.Configuration
             services.AddScoped<IPregnancyPolicy, DefaultPregnancyPolicy>();
             services.AddScoped<IRansomService, RansomService>();
             services.AddScoped<IRansomDecisionService, RansomDecisionService>();
+            services.AddScoped<IRansomPricingService, RansomPricingService>();
             services.AddScoped<IResearchService, ResearchService>();
             services.AddSingleton<IStarmapService>(_ => new StarmapService(Array.Empty<StarSystem>()));
             services.AddScoped<IRouteService, RouteService>();


### PR DESCRIPTION
## Summary
- model ongoing ransom talks using `PendingRansom` and per-turn processing
- compute ransom amounts from captive rank, parents and faction strength
- charge marketplace fee and support keeping captives as harem members

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68ad9778480883218c8865763c521c04