### PR TITLE
Integrate ransom start and harem options in capture workflow

### DIFF
--- a/Application/TurnProcessor.cs
+++ b/Application/TurnProcessor.cs
@@ -12,7 +12,7 @@ namespace SkyHorizont.Application
 
     /// <summary>
     /// Orchestrates the monthly turn:
-    /// Clock → Lifecycle → Social (plan/resolve) → Affection → Morale → Intrigue → Economy.
+    /// Clock → Lifecycle → Social (plan/resolve) → Affection → Morale → Intrigue → Ransoms → Economy.
     /// </summary>
     public sealed class TurnProcessor : ITurnProcessor
     {
@@ -25,6 +25,7 @@ namespace SkyHorizont.Application
         private readonly IMoraleService _morale;
         private readonly ICharacterLifecycleService _lifecycle;
         private readonly IIntrigueService _intrigue;
+        private readonly IRansomService _ransom;
         private readonly IEconomyService _economy;
 
         public TurnProcessor(
@@ -37,6 +38,7 @@ namespace SkyHorizont.Application
             IMoraleService morale,
             ICharacterLifecycleService lifecycle,
             IIntrigueService intrigue,
+            IRansomService ransom,
             IEconomyService economy)
         {
             _clock      = clock;
@@ -51,6 +53,7 @@ namespace SkyHorizont.Application
             _lifecycle = lifecycle;
 
             _intrigue  = intrigue;
+            _ransom   = ransom;
             _economy   = economy;
         }
 
@@ -95,8 +98,10 @@ namespace SkyHorizont.Application
 
             // 6) Intrigue (plots progress, exposure, recruitment, defections, blackmail)
             SafeRun("Intrigue.TickPlots", () => _intrigue.TickPlots());
+            // 7) Ransom negotiations (one step per captive)
+            SafeRun("Ransom.ProcessPending", () => _ransom.ProcessPendingRansoms());
 
-            // 7) Economy (upkeep, trade/tariffs/smuggling, loans)
+            // 8) Economy (upkeep, trade/tariffs/smuggling, loans)
             SafeRun("Economy.EndOfTurnUpkeep", () => _economy.EndOfTurnUpkeep());
         }
 

--- a/Domain/Services/ILocationService.cs
+++ b/Domain/Services/ILocationService.cs
@@ -24,6 +24,7 @@ namespace SkyHorizont.Domain.Services
         void AddCitizenToPlanet(Guid character, Guid locationId);
         void AddPassengerToFleet(Guid character, Guid fleetId);
         void StageAtHolding(Guid character, Guid locationId);
+        void KeepInHarem(Guid captiveId, Guid captorId);
 
         bool IsPrisonerOf(Guid prisonerId, Guid captorId);
     }

--- a/Domain/Services/IRansomService.cs
+++ b/Domain/Services/IRansomService.cs
@@ -18,6 +18,11 @@ namespace SkyHorizont.Domain.Services
         /// either by payment or by exhausting all candidates.
         /// </summary>
         bool ProcessRansomTurn(Guid captiveId);
+        /// <summary>
+        /// Processes a negotiation turn for all pending ransoms.
+        /// </summary>
+        void ProcessPendingRansoms();
+
 
         /// <summary>
         /// Handles a captive whose ransom was not paid in time by listing them on the

--- a/Infrastructure/DomainServices/RansomService.cs
+++ b/Infrastructure/DomainServices/RansomService.cs
@@ -96,6 +96,14 @@ namespace SkyHorizont.Infrastructure.DomainServices
             return pending.NextIndex < pending.CandidatePayers.Count;
         }
 
+
+        public void ProcessPendingRansoms()
+        {
+            var ids = _pending.Keys.ToList();
+            foreach (var id in ids)
+                ProcessRansomTurn(id);
+        }
+
         public void HandleUnpaidRansom(Guid captiveId, Guid captorId, int amount, bool captorIsFaction)
         {
             var captive = _cmdRepo.GetById(captiveId);

--- a/Tests/Common/LifeCycleTest.cs
+++ b/Tests/Common/LifeCycleTest.cs
@@ -12,6 +12,7 @@ using SkyHorizont.Infrastructure.Social.IntentRules;
 using SkyHorizont.Infrastructure.Testing;
 using Xunit;
 using SkyHorizont.Infrastructure.Persistence.Repositories;
+using Moq;
 
 namespace SkyHorizont.Tests.Common
 {
@@ -43,7 +44,8 @@ namespace SkyHorizont.Tests.Common
             var mortality = new GompertzMortalityModel();
             var nameGen = new NameGenerator(rng);
             var inherit = new SimplePersonalityInheritanceService(rng);
-            var loc = new LocationService(planets, fleets);
+            var ransom = new Mock<IRansomService>();
+            var loc = new LocationService(planets, fleets, ransom.Object);
             var pregPolicy = new DefaultPregnancyPolicy(rng, opinions, loc);
             var skillInh = new SimpleSkillInheritanceService();
             var faction = new FactionService(factions, planets);

--- a/Tests/Domain/ChildInheritanceVariationTests.cs
+++ b/Tests/Domain/ChildInheritanceVariationTests.cs
@@ -118,6 +118,7 @@ namespace SkyHorizont.Tests.Domain
             public void AddCitizenToPlanet(Guid character, Guid locationId) { }
             public void AddPassengerToFleet(Guid character, Guid fleetId) { }
             public void StageAtHolding(Guid character, Guid fleetId) { }
+            public void KeepInHarem(Guid captiveId, Guid captorId) { }
             public bool IsPrisonerOf(Guid prisonerId, Guid captorId) => false;
         }
     }

--- a/Tests/Domain/ChildNamingTests.cs
+++ b/Tests/Domain/ChildNamingTests.cs
@@ -99,6 +99,7 @@ namespace SkyHorizont.Tests.Domain
             public void AddCitizenToPlanet(Guid character, Guid locationId) { }
             public void AddPassengerToFleet(Guid character, Guid fleetId) { }
             public void StageAtHolding(Guid character, Guid locationId) { }
+            public void KeepInHarem(Guid captiveId, Guid captorId) { }
             public bool IsPrisonerOf(Guid prisonerId, Guid captorId) => false;
         }
 


### PR DESCRIPTION
## Summary
- start ransom negotiations automatically when a prisoner is staged on a fleet
- allow captors to convert held prisoners into harem members via `ILocationService`
- update tests for new capture flow

## Testing
- `dotnet test`

------
https://chatgpt.com/codex/tasks/task_e_68adabe39f78832193a9aace456e4a3b